### PR TITLE
Control output

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (0.1.1)
+    MovableInkAWS (0.1.2)
       aws-sdk (~> 2.10, >= 2.10.0)
 
 GEM

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -51,7 +51,11 @@ module MovableInk
     end
 
     def availability_zone
-      @availability_zone ||= `ec2metadata --availability-zone`.chomp rescue raise(MovableInk::AWS::Errors::EC2Required)
+      @availability_zone ||= begin
+        az = `ec2metadata --availability-zone 2>/dev/null`.chomp
+        raise(MovableInk::AWS::Errors::EC2Required) if az.empty?
+        az
+      end
     end
 
     def my_region
@@ -59,7 +63,11 @@ module MovableInk
     end
 
     def instance_id
-      @instance_id ||= `ec2metadata --instance-id`.chomp rescue raise(MovableInk::AWS::Errors::EC2Required)
+      @instance_id ||= begin
+        az = `ec2metadata --instance-id 2>/dev/null`.chomp
+        raise(MovableInk::AWS::Errors::EC2Required) if az.empty?
+        az
+      end
     end
 
     def datacenter(region: my_region)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '0.1.1'
+    VERSION = '0.1.2'
   end
 end

--- a/spec/aws_spec.rb
+++ b/spec/aws_spec.rb
@@ -13,19 +13,19 @@ describe MovableInk::AWS do
   context "inside EC2" do
     it "should call ec2metadata to get the instance ID" do
       aws = MovableInk::AWS.new
-      expect(aws).to receive(:`).with('ec2metadata --instance-id').and_return('i-12345')
+      expect(aws).to receive(:`).with('ec2metadata --instance-id 2>/dev/null').and_return("i-12345\n")
       expect(aws.instance_id).to eq('i-12345')
     end
 
     it "should call ec2metadata to get the availability zone" do
       aws = MovableInk::AWS.new
-      expect(aws).to receive(:`).with('ec2metadata --availability-zone').and_return("us-east-1a\n")
+      expect(aws).to receive(:`).with('ec2metadata --availability-zone 2>/dev/null').and_return("us-east-1a\n")
       expect(aws.availability_zone).to eq('us-east-1a')
     end
 
     it "should find the datacenter by region" do
       aws = MovableInk::AWS.new
-      expect(aws).to receive(:`).with('ec2metadata --availability-zone').and_return("us-east-1a\n")
+      expect(aws).to receive(:`).with('ec2metadata --availability-zone 2>/dev/null').and_return("us-east-1a\n")
       expect(aws.datacenter).to eq('iad')
     end
 

--- a/spec/aws_spec.rb
+++ b/spec/aws_spec.rb
@@ -37,6 +37,7 @@ describe MovableInk::AWS do
 
         expect(aws).to receive(:notify_slack).exactly(9).times
         expect(aws).to receive(:sleep).exactly(9).times.and_return(true)
+        expect(STDOUT).to receive(:puts).exactly(9).times
 
         aws.run_with_backoff { ec2.describe_instances } rescue nil
       end


### PR DESCRIPTION
Under certain circumstances, the gem will result in a message getting to the console about being unable to find `ec2metadata`.  We shouldn't be leaking to STDOUT/STDERR in this way.  We also write to the console in some tests when really we should be confirming in the spec that the console write occurs.