### PR TITLE
Catch service errors in run_with_backoff without retrying

### DIFF
--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -53,7 +53,7 @@ module MovableInk
             notify_and_sleep(sleep_time, $!.class)
           end
         rescue Aws::Errors::ServiceError => e
-          message = "#{e.class}: #{e.message}"
+          message = "#{e.class}: #{e.message}\nFrom `#{e.backtrace.last.gsub("`","'")}`"
           notify_slack(subject: 'Unhandled AWS API Error',
                        message: message)
           puts message

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -43,7 +43,6 @@ module MovableInk
                Aws::AutoScaling::Errors::ThrottledException,
                Aws::S3::Errors::SlowDown,
                Aws::Route53::Errors::ThrottlingException,
-               Aws::Route53::Errors::ServiceError,
                Aws::SSM::Errors::TooManyUpdates,
                Aws::Athena::Errors::ThrottlingException,
                MovableInk::AWS::Errors::NoEnvironmentTagError
@@ -53,6 +52,12 @@ module MovableInk
           else
             notify_and_sleep(sleep_time, $!.class)
           end
+        rescue Aws::Errors::ServiceError => e
+          message = "#{e.class}: #{e.message}"
+          notify_slack(subject: 'API Error',
+                       message: message)
+          puts message
+          raise MovableInk::AWS::Errors::ServiceError
         end
       end
       raise MovableInk::AWS::Errors::FailedWithBackoff

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -54,7 +54,7 @@ module MovableInk
           end
         rescue Aws::Errors::ServiceError => e
           message = "#{e.class}: #{e.message}"
-          notify_slack(subject: 'API Error',
+          notify_slack(subject: 'Unhandled AWS API Error',
                        message: message)
           puts message
           raise MovableInk::AWS::Errors::ServiceError

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -43,6 +43,7 @@ module MovableInk
                Aws::AutoScaling::Errors::ThrottledException,
                Aws::S3::Errors::SlowDown,
                Aws::Route53::Errors::ThrottlingException,
+               Aws::Route53::Errors::PriorRequestNotComplete,
                Aws::SSM::Errors::TooManyUpdates,
                Aws::Athena::Errors::ThrottlingException,
                MovableInk::AWS::Errors::NoEnvironmentTagError

--- a/lib/movable_ink/aws/errors.rb
+++ b/lib/movable_ink/aws/errors.rb
@@ -1,6 +1,7 @@
 module MovableInk
   class AWS
     module Errors
+      class ServiceError < StandardError; end
       class FailedWithBackoff < StandardError; end
       class EC2Required < StandardError; end
       class NoEnvironmentTagError < StandardError; end


### PR DESCRIPTION
We currently back off and retry things that will likely never succeed.  For example, calling `Route53#list_resource_record_sets` with a non-existent `hosted_zone_id` will not magically start working.  This change rescues the service errors and notifies about them, but avoids the next step of backing off and retrying in those cases.