### PR TITLE
Make elasticache module more flexible

### DIFF
--- a/lib/movable_ink/aws/elasticache.rb
+++ b/lib/movable_ink/aws/elasticache.rb
@@ -6,41 +6,58 @@ module MovableInk
         @elasticache_client[region] ||= Aws::ElastiCache::Client.new(region: region)
       end
 
-      def replication_group(role)
+      def replication_group(name)
         run_with_backoff do
-          @replication_group ||= elasticache.describe_replication_groups({replication_group_id: "#{mi_env}-#{role}"}).replication_groups.first
+          @replication_group ||= elasticache
+            .describe_replication_groups(replication_group_id: name)
+            .replication_groups
+            .first
         end
       end
 
-      def elasticache_primary(role)
-        replication_group(role).node_groups
-                               .first
-                               .primary_endpoint
-                               .address
-      end
-
-      def all_elasticache_replicas(role)
-        replication_group(role).node_groups
-                               .first
-                               .node_group_members
-                               .select{|ng| ng.current_role == 'replica'}
-                               .map{|member| member.read_endpoint.address}
-      end
-
-      def elasticache_replica_in_my_az(role)
-        members = replication_group(role).node_groups
-                                         .first
-                                         .node_group_members
-                                         .select{|ng| ng.preferred_availability_zone == availability_zone}
-        begin
-          members.select{|ng| ng.current_role == 'replica'}
+      def elasticache_primary(name)
+        replication_group(name)
+          .node_groups
           .first
-          .read_endpoint
+          .primary_endpoint
           .address
+      end
+
+      def node_group_members(name)
+        replication_group(name)
+          .node_groups
+          .first
+          .node_group_members
+      end
+
+      def node_group_members_in_my_az(name)
+        node_group_members(name)
+          .select { |ng| ng.preferred_availability_zone == availability_zone }
+      end
+
+      def elasticache_replicas(name)
+        node_group_members(name)
+          .select { |ng| ng.current_role == 'replica' }
+      end
+
+      def all_elasticache_replicas(name)
+        elasticache_replicas(name)
+          .map { |replica| replica.read_endpoint.address }
+      end
+
+      def elasticache_replica_in_my_az(name)
+        members = node_group_members_in_my_az(name)
+        begin
+          members
+            .select{|ng| ng.current_role == 'replica'}
+            .first
+            .read_endpoint
+            .address
         rescue NoMethodError
-          members.first
-                 .read_endpoint
-                 .address
+          members
+            .first
+            .read_endpoint
+            .address
         end
       end
     end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '0.3.0'
+    VERSION = '0.3.1'
   end
 end

--- a/spec/elasticache_spec.rb
+++ b/spec/elasticache_spec.rb
@@ -11,8 +11,8 @@ describe MovableInk::AWS::ElastiCache do
             primary_endpoint: {address: 'primary'},
             node_group_members: [
               {preferred_availability_zone: 'us-foo-1a',
-              read_endpoint: {address: 'address-1a'},
-              current_role: 'replica' },
+                read_endpoint: {address: 'address-1a'},
+                current_role: 'replica' },
               {preferred_availability_zone: 'us-foo-1a',
                 read_endpoint: {address: 'address-1a-primary'},
                 current_role: 'primary' },
@@ -29,7 +29,6 @@ describe MovableInk::AWS::ElastiCache do
 
     before(:each) do
       elasticache.stub_responses(:describe_replication_groups, replication_group)
-      allow(aws).to receive(:mi_env).and_return('test')
       allow(aws).to receive(:elasticache).and_return(elasticache)
     end
 


### PR DESCRIPTION
As currently implemented, the gem is very prescriptive about naming of ElastiCache clusters.  We were using this at one point when experimenting with `dynamic_links_redis` in ElastiCache, but that experiment has since been abandoned.  `sherlock` uses ElastiCache for the `content-events-redis`, and since it is becoming autoscaled, it needs to look up its ElastiCache addresses.  This allows a cluster name to be passed in, rather than a role that is then combined with the environment.