### PR TITLE
#instances should parse role list and match against parsed role

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (0.3.0)
+    MovableInkAWS (0.3.3)
       aws-sdk (= 2.11.240)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.0.2)
+    aws-eventstream (1.0.3)
     aws-sdk (2.11.240)
       aws-sdk-resources (= 2.11.240)
     aws-sdk-core (2.11.240)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -94,15 +94,13 @@ module MovableInk
       end
 
       def instances(role:, region: my_region, availability_zone: nil)
-        role_pattern = mi_env == 'production' ? "^#{role}$" : "^*#{role}*$"
-        role_pattern = role_pattern.gsub('**','*').gsub('*','.*')
         instances = all_instances(region: region).select { |instance|
-          instance.tags.detect { |tag|
-            tag.key == 'mi:roles'&&
-              Regexp.new(role_pattern).match(tag.value) &&
-              !tag.value.include?('decommissioned')
+          instance.tags.select{ |tag| tag.key == 'mi:roles' }.detect { |tag|
+            roles = tag.value.split(/\s*,\s*/)
+            roles.include?(role) && !roles.include?('decommissioned')
           }
         }
+
         if availability_zone
           instances.select { |instance|
             instance.placement.availability_zone == availability_zone


### PR DESCRIPTION
In non-prod environments we were doing a regex-based role matching, which was causing ojos capturama_varnish configs to pick up _all_ varnishes. This should normalize behavior between prod and staging and only match machines that actually contain the role.