### PR TITLE
Create signed api gateway method

### DIFF
--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -9,7 +9,9 @@ Gem::Specification.new do |s|
   s.authors       = ['Matt Chesler']
   s.email         = 'mchesler@movableink.com'
 
-  s.add_runtime_dependency 'aws-sdk',  '2.11.240'
+  s.add_runtime_dependency 'aws-sdk',   '2.11.240'
+  s.add_runtime_dependency 'aws-sigv4', '~> 1.1'
+  s.add_runtime_dependency 'httparty',  '0.16.3'
 
   all_files  = `git ls-files`.split("\n")
   test_files = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -9,6 +9,7 @@ require_relative 'aws/ssm'
 require_relative 'aws/athena'
 require_relative 'aws/s3'
 require_relative 'aws/elasticache'
+require_relative 'aws/api_gateway'
 
 
 module MovableInk
@@ -21,6 +22,7 @@ module MovableInk
     include Athena
     include S3
     include ElastiCache
+    include ApiGateway
 
     class << self
       def regions

--- a/lib/movable_ink/aws/api_gateway.rb
+++ b/lib/movable_ink/aws/api_gateway.rb
@@ -1,0 +1,30 @@
+require 'aws-sdk'
+require 'aws-sigv4'
+require 'httparty'
+
+module MovableInk
+  class AWS
+    module ApiGateway
+      def post_signed_gateway_request(gateway_url:, region:, body:)
+        credentials = Aws::CredentialProviderChain.new.resolve.credentials
+
+        signer = Aws::Sigv4::Signer.new({
+          service: 'execute-api',
+          region: region,
+          credentials: credentials
+        })
+
+        signature = signer.sign_request({
+          http_method: 'POST',
+          url: gateway_url,
+          body: body,
+        })
+
+        HTTParty.post(gateway_url, {
+          headers: signature.headers,
+          body: body,
+        })
+      end
+    end
+  end
+end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '0.3.5'
+    VERSION = '0.4.0'
   end
 end


### PR DESCRIPTION
Related to https://app.clubhouse.io/movableink/story/24636/simplify-forcing-a-full-ami-rebuild-deploy

The method is pretty specific about post requests, we could make a more generic method in the future if necessary. It's a pretty niche use case to have to send signed requests to API Gateway.