### PR TITLE
Fix MovableInk::AWS.new().me

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.0.4)
+    MovableInkAWS (1.0.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-core (~> 3)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -67,9 +67,9 @@ module MovableInk
 
       def instance_id
         @instance_id ||= begin
-          az = `ec2metadata --instance-id 2>/dev/null`.chomp
-          raise(MovableInk::AWS::Errors::EC2Required) if az.empty?
-          az
+          id = `ec2metadata --instance-id 2>/dev/null`.chomp
+          raise(MovableInk::AWS::Errors::EC2Required) if id.empty?
+          id
         end
       end
 
@@ -90,7 +90,7 @@ module MovableInk
       end
 
       def me
-        @me ||= all_instances.select{|instance| instance.instance_id == instance_id}
+        @me ||= all_instances.select{|instance| instance.instance_id == instance_id}.first rescue nil
       end
 
       def instances(role:, exclude_roles: [], region: my_region, availability_zone: nil, exact_match: false)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.4'
+    VERSION = '1.0.5'
   end
 end


### PR DESCRIPTION
`MovableInk::AWS.new.me` returns an array when it should return just the instance.

Cleanup specs a bit.

NOTE: There are two spots in the termination handler in movableink/provisioning that will need to change with this update.  A second PR is forthcoming.

[ch29773]