### PR TITLE
Enable notify_slack to be used outside EC2 without raising an exception

### DIFF
--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -39,6 +39,7 @@ module MovableInk
       if global_service
         @availability_zone = 'us-east-1a'
         @instance_id = global_service
+        @ipv4 = global_service
       end
     end
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.9'
+    VERSION = '1.0.10'
   end
 end


### PR DESCRIPTION
Currently, if `notify_slack` is called from outside EC2, it raises `MovableInk::AWS::Errors::EC2Required` because the notify method includes the instance IP in the alert.  There are cases where we want a `notify_slack` call to succeed, but it may not be called from an EC2 instance.  The use case that immediately comes to mind is our rollback command.


[ch31234]