### PR TITLE
[ch37377] Add ability to read mi_env from a cache file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.0.11)
+    MovableInkAWS (1.0.12)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -8,8 +8,16 @@ module MovableInk
         @ec2_client[region] ||= Aws::EC2::Client.new(region: region)
       end
 
+      def mi_env_cache_file_path
+        '/etc/movableink/mi_env'
+      end
+
       def mi_env
-        @mi_env ||= load_mi_env
+        @mi_env ||= if File.exist?(mi_env_cache_file_path)
+          File.read(mi_env_cache_file_path)
+        else
+          load_mi_env
+        end
       end
 
       def load_mi_env

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.11'
+    VERSION = '1.0.12'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -37,6 +37,14 @@ describe MovableInk::AWS::EC2 do
       ])
     }
 
+    it 'will read mi_env from disk when the cache file exists' do
+      f = Tempfile.new
+      f.write('staging')
+      f.close
+      allow(aws).to receive(:mi_env_cache_file_path).and_return(f.path)
+      expect(aws.mi_env).to eq('staging')
+    end
+
     it "should find the environment from the current instance's tags" do
       ec2.stub_responses(:describe_tags, tag_data)
       allow(aws).to receive(:my_region).and_return('us-east-1')

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -38,7 +38,7 @@ describe MovableInk::AWS::EC2 do
     }
 
     it 'will read mi_env from disk when the cache file exists' do
-      f = Tempfile.new
+      f = Tempfile.new('cache')
       f.write('staging')
       f.close
       allow(aws).to receive(:mi_env_cache_file_path).and_return(f.path)


### PR DESCRIPTION
## Current Behavior

We get get the value for `mi_env` from instance tags

## Why do we need this change?

This should alleviate some pressure of API calls we send to the EC2 APIs

:house: [ch37377](https://app.clubhouse.io/movableink/story/37377)
