### PR TITLE
[ch37377] Prevent call to get thopter instances from calling describe…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.0.13)
+    MovableInkAWS (1.0.14)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -29,23 +29,12 @@ module MovableInk
         raise MovableInk::AWS::Errors::NoEnvironmentTagError
       end
 
-      def thopter_filter
-        [{
-          name: 'tag:mi:roles',
-          values: ['*thopter*']
-        },
-        {
-          name: 'tag:mi:env',
-          values: [mi_env]
-        },
-        {
-          name: 'instance-state-name',
-          values: ['running']
-        }]
-      end
-
       def thopter_instance
-        @thopter_instance ||= load_all_instances('us-east-1', filter: thopter_filter)
+        @thopter_instance ||= all_instances(region: 'us-east-1').select do |instance|
+          instance.tags.select{ |tag| tag.key == 'mi:roles' }.detect do |tag|
+            tag.value.include?('thopter')
+          end
+        end
       end
 
       def all_instances(region: my_region, no_filter: false)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.13'
+    VERSION = '1.0.14'
   end
 end


### PR DESCRIPTION
… instances

## Current Behavior

The `thopter_instance` method calls `load_all_instances` instead of using `all_instances` which would have a cache of the instances we need to access

## Why do we need this change?

To make fewer calls to the EC2 APIs

:house: [ch37377](https://app.clubhouse.io/movableink/story/37377)
