### PR TITLE
Send notification if/when exponential backoff retries are exceeded

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.0.15)
+    MovableInkAWS (1.0.16)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -20,7 +20,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.321.0)
+    aws-partitions (1.322.0)
     aws-sdk-athena (1.25.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -77,7 +77,7 @@ module MovableInk
             notify_and_sleep(sleep_time, $!.class)
           end
         rescue Aws::Errors::ServiceError => e
-          message = "#{e.class}: #{e.message}\nFrom #{$0}\n```\n#{e.backtrace.first(3).gsub("`","'")}\n```"
+          message = "#{e.class}: #{e.message}\nFrom #{$0}\n```\n#{e.backtrace.first(3).join("\n").gsub("`","'")}\n```"
           notify_slack(subject: 'Unhandled AWS API Error', message: message)
           puts message
           raise MovableInk::AWS::Errors::ServiceError

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -77,12 +77,15 @@ module MovableInk
             notify_and_sleep(sleep_time, $!.class)
           end
         rescue Aws::Errors::ServiceError => e
-          message = "#{e.class}: #{e.message}\nFrom `#{e.backtrace.last.gsub("`","'")}`"
+          message = "#{e.class}: #{e.message}\nFrom #{$0}\n```\n#{e.backtrace.first(3).gsub("`","'")}\n```"
           notify_slack(subject: 'Unhandled AWS API Error', message: message)
           puts message
           raise MovableInk::AWS::Errors::ServiceError
         end
       end
+      message = "From: #{$0}\n```\n#{Thread.current.backtrace.first(3).join("\n").gsub("`","'")}\n```"
+      notify_slack(subject: "AWS API failed after #{tries} attempts", message: message)
+      puts message
       raise MovableInk::AWS::Errors::FailedWithBackoff
     end
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.15'
+    VERSION = '1.0.16'
   end
 end

--- a/spec/aws_spec.rb
+++ b/spec/aws_spec.rb
@@ -42,9 +42,9 @@ describe MovableInk::AWS do
         ec2 = Aws::EC2::Client.new(stub_responses: true)
         ec2.stub_responses(:describe_instances, 'RequestLimitExceeded')
 
-        expect(aws).to receive(:notify_slack).exactly(9).times
+        expect(aws).to receive(:notify_slack).exactly(10).times
         expect(aws).to receive(:sleep).exactly(9).times.and_return(true)
-        expect(STDOUT).to receive(:puts).exactly(9).times
+        expect(STDOUT).to receive(:puts).exactly(10).times
 
         aws.run_with_backoff { ec2.describe_instances } rescue nil
       end
@@ -64,9 +64,9 @@ describe MovableInk::AWS do
         ec2 = Aws::EC2::Client.new(stub_responses: true)
         ec2.stub_responses(:describe_instances, 'RequestLimitExceeded')
 
-        expect(aws).to receive(:notify_slack).exactly(1).times
+        expect(aws).to receive(:notify_slack).exactly(2).times
         expect(aws).to receive(:sleep).exactly(9).times.and_return(true)
-        expect(STDOUT).to receive(:puts).exactly(1).times
+        expect(STDOUT).to receive(:puts).exactly(2).times
 
         aws.run_with_backoff(quiet: true) { ec2.describe_instances } rescue nil
       end
@@ -77,6 +77,8 @@ describe MovableInk::AWS do
         ec2.stub_responses(:describe_instances, 'RequestLimitExceeded')
 
         expect(aws).to receive(:notify_and_sleep).exactly(9).times
+        expect(aws).to receive(:notify_slack).exactly(1).times
+        expect(STDOUT).to receive(:puts).exactly(1).times
         expect{ aws.run_with_backoff { ec2.describe_instances } }.to raise_error(MovableInk::AWS::Errors::FailedWithBackoff)
       end
     end

--- a/spec/ssm_spec.rb
+++ b/spec/ssm_spec.rb
@@ -82,6 +82,8 @@ describe MovableInk::AWS::SSM do
       allow(aws).to receive(:ssm_client).and_return(1)
       allow(aws).to receive(:ssm_client_failover).and_return(2)
       allow(aws).to receive(:notify_and_sleep).and_return(nil)
+      allow(aws).to receive(:notify_slack).and_return(nil)
+      allow(STDOUT).to receive(:puts).and_return(nil)
 
       results = []
       calls = 0


### PR DESCRIPTION
## Current Behavior

We raise an exception when retries are exceeded, but it's most likely swallowed up somewhere and never surfaced

## Why do we need this change?

We'd like to know if/when we're unable to complete AWS API requests after multiple retries.

## Implementation Details

- Augment slack notifications of failures
- Notify via slack when retries are exhausted

#### Dependencies (if any)

None

:house: [ch38286](https://app.clubhouse.io/movableink/story/38286)
