### PR TITLE
Do not pull entire instance inventory to find statsd instances

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.0.17)
+    MovableInkAWS (1.0.18)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -127,15 +127,15 @@ module MovableInk
       end
 
       def statsd_host
-        instance_ip_addresses_by_role(role: 'statsd', availability_zone: availability_zone).sample
+        instance_ip_addresses_by_role(role: 'statsd', availability_zone: availability_zone, use_cache: false).sample
       end
 
       def private_ip_addresses(instances)
         instances.map(&:private_ip_address)
       end
 
-      def instance_ip_addresses_by_role(role:, exclude_roles: [], region: my_region, availability_zone: nil, exact_match: false)
-        private_ip_addresses(instances(role: role, exclude_roles: exclude_roles, region: region, availability_zone: availability_zone, exact_match: exact_match))
+      def instance_ip_addresses_by_role(role:, exclude_roles: [], region: my_region, availability_zone: nil, exact_match: false, use_cache: true)
+        private_ip_addresses(instances(role: role, exclude_roles: exclude_roles, region: region, availability_zone: availability_zone, exact_match: exact_match, use_cache: use_cache))
       end
 
       def instance_ip_addresses_by_role_ordered(role:, exclude_roles: [], region: my_region, exact_match: false)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.0.17'
+    VERSION = '1.0.18'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -153,18 +153,6 @@ describe MovableInk::AWS::EC2 do
               availability_zone: availability_zone
             }
           },
-          {
-            tags: [
-              {
-                key: 'mi:roles',
-                value: 'something_else'
-              }
-            ],
-            private_ip_address: '10.0.0.3',
-            placement: {
-              availability_zone: availability_zone
-            }
-          }
         ]])
       }
 


### PR DESCRIPTION
## Current Behavior

When `update_environment.rb` runs during ASG instance boot, it looks up a statsd instance to store in the local config.  The statsd instance lookup retrieves the entire inventory of ec2 instances rather than filtering in the EC2 API

## Why do we need this change?

Decrease load on the EC2 API while AWS works to extract their heads from an uncomfortable place

## Implementation Details

Use filtered, uncached instance lookup

#### Dependencies (if any)

:house: [ch38286](https://app.clubhouse.io/movableink/story/38286)
