### PR TITLE
More aws gem updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,10 +21,10 @@ GEM
   specs:
     aws-eventstream (1.1.0)
     aws-partitions (1.328.0)
-    aws-sdk-athena (1.28.0)
+    aws-sdk-athena (1.27.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-autoscaling (1.38.0)
+    aws-sdk-autoscaling (1.37.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-cloudwatch (1.39.0)
@@ -41,10 +41,10 @@ GEM
     aws-sdk-elasticache (1.37.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-kms (1.34.0)
+    aws-sdk-kms (1.33.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-rds (1.86.0)
+    aws-sdk-rds (1.85.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-route53 (1.36.0)
@@ -54,7 +54,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.99.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.1)
-    aws-sdk-sns (1.25.0)
+    aws-sdk-sns (1.24.0)
       aws-sdk-core (~> 3, >= 3.71.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-ssm (1.80.0)
@@ -93,4 +93,4 @@ DEPENDENCIES
   rspec (~> 3.6)
 
 BUNDLED WITH
-   1.17.3
+   2.1.3

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.1.2'
+    VERSION = '1.1.3'
   end
 end


### PR DESCRIPTION
## Current Behavior

The gem is still non-functional

## Why do we need this change?

Non-functional gems are not particularly useful

## Implementation Details

Change more AWS gem versions, bump our version

#### Dependencies (if any)

:house: [ch39171](https://app.clubhouse.io/movableink/story/39171)
