### PR TITLE
Add throttling exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.1.4)
+    MovableInkAWS (1.1.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -63,6 +63,7 @@ module MovableInk
                Aws::EC2::Errors::ResourceAlreadyAssociated,
                Aws::EC2::Errors::Unavailable,
                Aws::SNS::Errors::ThrottledException,
+               Aws::AutoScaling::Errors::Throttling,
                Aws::AutoScaling::Errors::ThrottledException,
                Aws::S3::Errors::SlowDown,
                Aws::Route53::Errors::Throttling,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.1.4'
+    VERSION = '1.1.5'
   end
 end


### PR DESCRIPTION
## Current Behavior

The autoscaling sdk can throw a throttling exception we don't handle

## Why do we need this change?

We want to handle this exception

:house: [ch29587](https://app.clubhouse.io/movableink/story/29587)
