### PR TITLE
Use syntax that will work with older versions of ruby

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.2.0)
+    MovableInkAWS (1.2.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/eks.rb
+++ b/lib/movable_ink/aws/eks.rb
@@ -13,9 +13,11 @@ module MovableInk
         client = eks(region: region)
 
         resp = run_with_backoff do
-          client.describe_cluster({ name: cluster_name })
-        rescue Aws::EKS::Errors::ResourceNotFoundException
-          return nil
+          begin
+            client.describe_cluster({ name: cluster_name })
+          rescue Aws::EKS::Errors::ResourceNotFoundException
+            return nil
+          end
         end
 
         cluster_arn = resp.cluster.arn

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.2.0'
+    VERSION = '1.2.1'
   end
 end


### PR DESCRIPTION
## Current Behavior

Current syntax fails on ruby 2.2

#### Dependencies (if any)

:house: [ch41837](https://app.clubhouse.io/movableink/story/41837)
