### PR TITLE
Add EKS handling for an EKS throttling exception

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (1.2.1)
+    MovableInkAWS (1.2.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -64,6 +64,7 @@ module MovableInk
         rescue Aws::EC2::Errors::RequestLimitExceeded,
                Aws::EC2::Errors::ResourceAlreadyAssociated,
                Aws::EC2::Errors::Unavailable,
+               Aws::EKS::Errors::TooManyRequestsException,
                Aws::SNS::Errors::ThrottledException,
                Aws::AutoScaling::Errors::Throttling,
                Aws::AutoScaling::Errors::ThrottledException,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.2.1'
+    VERSION = '1.2.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

We don't handle throttling errors raised by the SDK

## Why do we need this change?

We want to perform backoff instead of failing

:house: [ch42985](https://app.clubhouse.io/movableink/story/42985)
