### PR TITLE
Integrate consul service discovery with MIAWS gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ gemspec
 
 group :test do
   gem 'rspec',    '~> 3.6'
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,11 +15,14 @@ PATH
       aws-sdk-sns (~> 1)
       aws-sdk-ssm (~> 1)
       aws-sigv4 (~> 1.1)
+      diplomat (= 2.4.2)
       httparty (= 0.16.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.1.0)
     aws-partitions (1.383.0)
     aws-sdk-athena (1.33.0)
@@ -66,7 +69,16 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    deep_merge (1.2.1)
     diff-lcs (1.3)
+    diplomat (2.4.2)
+      deep_merge (~> 1.0, >= 1.0.1)
+      faraday (>= 0.9, < 1.1.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    hashdiff (1.0.0)
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -75,6 +87,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0512)
     multi_xml (0.6.0)
+    multipart-post (2.1.1)
+    public_suffix (4.0.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -88,6 +102,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
+    safe_yaml (1.0.5)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
 
 PLATFORMS
   ruby
@@ -95,6 +114,7 @@ PLATFORMS
 DEPENDENCIES
   MovableInkAWS!
   rspec (~> 3.6)
+  webmock
 
 BUNDLED WITH
    2.1.3

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-ssm', '~> 1'
   s.add_runtime_dependency 'aws-sigv4', '~> 1.1'
   s.add_runtime_dependency 'httparty',  '0.16.3'
+  s.add_runtime_dependency 'diplomat',  '2.4.2'
 
   all_files  = `git ls-files`.split("\n")
   test_files = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-ec2'
+require 'diplomat'
 
 module MovableInk
   class AWS
@@ -75,34 +76,84 @@ module MovableInk
         @me ||= all_instances.select{|instance| instance.instance_id == instance_id}.first rescue nil
       end
 
-      def instances(role:, exclude_roles: [], region: my_region, availability_zone: nil, exact_match: false, use_cache: true)
-        roles = role.split(/\s*,\s*/)
-        if use_cache == false
-          filter = default_filter.push({
-            name: 'tag:mi:roles',
-            values: roles
-          })
-          instances = load_all_instances(region, filter: filter)
-        else
-          instances = all_instances(region: region).select { |instance|
-            instance.tags.select{ |tag| tag.key == 'mi:roles' }.detect { |tag|
-              tag_roles = tag.value.split(/\s*,\s*/)
-              if exact_match
-                tag_roles == roles
-              else
-                exclude_roles.push('decommissioned')
-                tag_roles.any? { |tag_role| roles.include?(tag_role) } && !tag_roles.any? { |role| exclude_roles.include?(role) }
-              end
+      def instances(role:, exclude_roles: [], region: my_region, availability_zone: nil, exact_match: false, use_cache: true, discovery_type: 'ec2')
+        if discovery_type == 'ec2'
+          roles = role.split(/\s*,\s*/)
+          if use_cache == false
+            filter = default_filter.push({
+              name: 'tag:mi:roles',
+              values: roles
+            })
+            instances = load_all_instances(region, filter: filter)
+          else
+            instances = all_instances(region: region).select { |instance|
+              instance.tags.select{ |tag| tag.key == 'mi:roles' }.detect { |tag|
+                tag_roles = tag.value.split(/\s*,\s*/)
+                if exact_match
+                  tag_roles == roles
+                else
+                  exclude_roles.push('decommissioned')
+                  tag_roles.any? { |tag_role| roles.include?(tag_role) } && !tag_roles.any? { |role| exclude_roles.include?(role) }
+                end
+              }
             }
-          }
-        end
+          end
 
-        if availability_zone
-          instances.select { |instance|
-            instance.placement.availability_zone == availability_zone
+          if availability_zone
+            instances.select { |instance|
+              instance.placement.availability_zone == availability_zone
+            }
+          else
+            instances
+          end
+        elsif discovery_type == 'consul'
+          if role == nil || role == ''
+            raise MovableInk::AWS::Errors::RoleNameRequiredError
+          end
+
+          if role.include? '_'
+            raise MovableInk::AWS::Errors::RoleNameInvalidError
+          end
+
+          Diplomat.configure do |config|
+            config.url = "https://localhost:8501"
+            config.options = { ssl: { verify: false } }
+          end
+
+          consul_instances = Diplomat::Service.get(role, :all, { :dc => datacenter(region) }).map { |node|
+            OpenStruct.new (
+              {
+              private_ip_address:  node.Address,
+              instance_id: node.NodeMeta['instance_id'],
+              tags: [
+                {
+                  key: 'Name',
+                  value: node.Node
+                },
+                {
+                  key: 'mi:roles',
+                  value: node.NodeMeta['mi_roles']
+                },
+                {
+                  key: 'mi:monitoring_roles',
+                  value: node.NodeMeta['mi_monitoring_roles']
+                }
+              ],
+              placement: {
+                availability_zone: node.NodeMeta['availability_zone']
+              }
+            })
           }
+
+          if availability_zone
+            consul_instances.select { |consul_instance|
+              consul_instance.placement[:availability_zone] == availability_zone
+            }
+          else
+            consul_instances
+          end
         else
-          instances
+          raise MovableInk::AWS::Errors::InvalidDiscoveryTypeError
         end
       end
 

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -121,7 +121,7 @@ module MovableInk
           config.options = { ssl: { verify: false } }
         end
 
-        consul_instances = Diplomat::Service.get(role, :all, { :dc => datacenter(region), :stale => true, :cached => true }).map { |node|
+        consul_instances = Diplomat::Service.get(role, :all, { :dc => datacenter(region: region), :stale => true, :cached => true }).map { |node|
           OpenStruct.new (
             {
             private_ip_address:  node.Address,

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -121,7 +121,7 @@ module MovableInk
           config.options = { ssl: { verify: false } }
         end
 
-        consul_instances = Diplomat::Service.get(role, :all, { :dc => datacenter(region) }).map { |node|
+        consul_instances = Diplomat::Service.get(role, :all, { :dc => datacenter(region), :stale => true, :cached => true }).map { |node|
           OpenStruct.new (
             {
             private_ip_address:  node.Address,

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -112,7 +112,7 @@ module MovableInk
           raise MovableInk::AWS::Errors::RoleNameRequiredError
         end
 
-        if role.include? '_'
+        if role.include?('_')
           raise MovableInk::AWS::Errors::RoleNameInvalidError
         end
 

--- a/lib/movable_ink/aws/errors.rb
+++ b/lib/movable_ink/aws/errors.rb
@@ -5,6 +5,9 @@ module MovableInk
       class FailedWithBackoff < StandardError; end
       class EC2Required < StandardError; end
       class NoEnvironmentTagError < StandardError; end
+      class InvalidDiscoveryTypeError < StandardError; end
+      class RoleNameRequiredError < StandardError; end
+      class RoleNameInvalidError < StandardError; end
     end
   end
 end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '1.3.3'
+    VERSION = '2.0.0'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -405,7 +405,6 @@ describe MovableInk::AWS::EC2 do
         allow(aws).to receive(:mi_env).and_return('test')
         allow(aws).to receive(:availability_zone).and_return(my_availability_zone)
         allow(aws).to receive(:my_region).and_return('us-east-1')
-        allow(aws).to receive(:datacenter).and_return('iad')
         allow(aws).to receive(:ec2).and_return(ec2)
       end
 

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -422,7 +422,7 @@ describe MovableInk::AWS::EC2 do
         allow(miaws).to receive(:my_region).and_return('us-east-1')
 
         json = JSON.generate(consul_app_service_instances)
-        stub_request(:get, "https://localhost:8501/v1/catalog/service/app?dc=#{my_datacenter}").
+        stub_request(:get, "https://localhost:8501/v1/catalog/service/app?dc=#{my_datacenter}&stale=true&cached=true").
          with(
             headers: {
             'Accept'=>'*/*',
@@ -435,7 +435,7 @@ describe MovableInk::AWS::EC2 do
         expect(app_instances.map{|i| i.tags.first[:value]}).to eq(['app_instance1', 'app_instance2'])
 
         json = JSON.generate(consul_ojos_service_instances)
-        stub_request(:get, "https://localhost:8501/v1/catalog/service/ojos?dc=#{my_datacenter}").
+        stub_request(:get, "https://localhost:8501/v1/catalog/service/ojos?dc=#{my_datacenter}&stale=true&cached=true").
          with(
            headers: {
           'Accept'=>'*/*',
@@ -453,7 +453,7 @@ describe MovableInk::AWS::EC2 do
         allow(miaws).to receive(:my_region).and_return('us-east-1')
 
         json = JSON.generate(consul_ojos_service_instances)
-        stub_request(:get, "https://localhost:8501/v1/catalog/service/ojos?dc=iad").
+        stub_request(:get, "https://localhost:8501/v1/catalog/service/ojos?dc=iad&stale=true&cached=true").
          with(
             headers: {
             'Accept'=>'*/*',


### PR DESCRIPTION
## Current Behavior
We currently do service discovery for our config generation scripts using the `miaws` gem which uses EC2 instance tags to determine what backends are available for a particular `role`.


## Why do we need this change?
In order to make our discovery process more efficient, robust and lively this PR integrates the `diplomat` consul gem with our `miaws` gem and provides `consul` service discovery as an option to retrieve valid backends for our services that are considered `healthy`

While `consul` service discovery does allow for filtering by availability zone it does not filter by the `decommissioned` or `ami` tag as we would be relying on health checks for consul backends.  This completely decouples us from having to read EC2 tags when doing service discovery and instead relying fully on consul.  Note: This also means that we need to update our infrastructure and operational playbooks so that anywhere that we `decommission` a node either automatically or manually we must now do that by putting the consul node in `maintenance` mode which removes that node from our list of service backends.  The other conditions that would make a consul node not show up in a service query would be if it's terminated or in a state where its consul client cannot communicate with the rest of the consul clients or servers for an extended period of time.


## Implementation Details
I tried to keep the resulting changes to our config generation ruby scripts as light as possible so instead of going with a `consul_service` attribute to `instances` I just repurposed the `role` attribute.  This might be more confusing to end users so I'll wait for feedback on that but it's important to note that when using `consul` discovery we aren't filtering on a `role` so much as we are on a `service` defined via `consul` service definitions.

I've also tried to maintain the EC2 instance data structure that we return from our current EC2 tag based discovery so we can again just plug in the `consul` based discovery into existing scripts and it should just work without too many changes.  This is apparent in how we create a `Name` tag in our response which mimics our EC2 `Name` tags we'd get from looking up EC2 instances.


#### Dependencies (if any)

https://github.com/WeAreFarmGeek/diplomat

:house: [ch41091](https://app.clubhouse.io/movableink/story/41091)
