### PR TITLE
Replacing underscores with dashes for role names passed to the consul sd method

### DIFF
--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -112,9 +112,10 @@ module MovableInk
           raise MovableInk::AWS::Errors::RoleNameRequiredError
         end
 
-        if role.include?('_')
-          raise MovableInk::AWS::Errors::RoleNameInvalidError
-        end
+        # We replace underscores with dashes in the role name in order to comply with
+        # consul service naming conventions while still retaining the role name we use
+        # within MI configuration.
+        role.gsub!('_', '-')
 
         consul_service_options = {
           dc: datacenter(region: region),

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -114,7 +114,7 @@ module MovableInk
 
         # We replace underscores with dashes in the role name in order to comply with
         # consul service naming conventions while still retaining the role name we use
-        # within MI configuration.
+        # within MI configuration
         role.gsub!('_', '-')
 
         consul_service_options = {

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -397,10 +397,6 @@ describe MovableInk::AWS::EC2 do
         expect{ aws.instances(role: nil, discovery_type: 'consul') }.to raise_error(MovableInk::AWS::Errors::RoleNameRequiredError)
       end
 
-      it "returns an error if an invalid role is passed" do
-        expect{ aws.instances(role: 'asset_proxy', discovery_type: 'consul') }.to raise_error(MovableInk::AWS::Errors::RoleNameInvalidError)
-      end
-
       it "returns all instances matching a consul service" do
         miaws = double(MovableInk::AWS)
         allow(miaws).to receive(:my_region).and_return('us-east-1')


### PR DESCRIPTION
## Current Behavior
We currently use underscores as a separator for role names within all of our MI configuration.


## Why do we need this change?
Now that we are migrating to use `consul` service discovery we have had to define our `service` names (`role` names) in `consul` using dashes instead of underscores as `consul` expects service names to be valid FQDN names.  In order to not break the MIAWS interface of passing regular old MI role names such as `cors_proxy` this PR adds a simple replacement inside of the `consul` service discovery method that turns underscores into dashes for `role`.  This means we can continue to use the MI roles in all of our configuration and ultimately our templates and pass the same role name to our AWS gem for `ec2` or `consul` service discovery and ensure that `consul` is getting the right `role` name to search on.


## Implementation Details

I debated whether to add this to the consul service discovery implementation in this gem or to simply add some logic in our `generate_haproxy_config` but ultimately decided to hide this bit of magic where it will work for all scripts that eventually call this gem in the future.


:house: [ch47787](https://app.clubhouse.io/movableink/story/47787)
