### PR TITLE
Bumping gem version for publishing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.1.0)
+    MovableInkAWS (2.1.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.1.0'
+    VERSION = '2.1.1'
   end
 end


### PR DESCRIPTION
## Why do we need this change?
This will publish changes from PR: https://github.com/movableink/awslib/pull/72 as version `2.1.1` of this gem.

:house: [ch47787](https://app.clubhouse.io/movableink/story/47787)
