### PR TITLE
Transforming consul service name from role locally so as not to produce any side effects upstream

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.1.1)
+    MovableInkAWS (2.1.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -112,11 +112,6 @@ module MovableInk
           raise MovableInk::AWS::Errors::RoleNameRequiredError
         end
 
-        # We replace underscores with dashes in the role name in order to comply with
-        # consul service naming conventions while still retaining the role name we use
-        # within MI configuration
-        role.gsub!('_', '-')
-
         consul_service_options = {
           dc: datacenter(region: region),
           stale: true,
@@ -125,7 +120,10 @@ module MovableInk
         }
         consul_service_options[:node_meta] = "availability_zone:#{availability_zone}" unless availability_zone.nil?
 
-        Diplomat::Health.service(role, consul_service_options).map { |endpoint|
+        # We replace underscores with dashes in the role name in order to comply with
+        # consul service naming conventions while still retaining the role name we use
+        # within MI configuration
+        Diplomat::Health.service(role.gsub('_', '-'), consul_service_options).map { |endpoint|
           OpenStruct.new (
           {
             private_ip_address: endpoint.Node['Address'],

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.1.1'
+    VERSION = '2.1.2'
   end
 end


### PR DESCRIPTION
## Current Behavior
The original version of this feature made a local change to a hash passed into the `instances_with_consul_discovery` method.  This change produced unintended side effects from the calling script side which breaks `generate_haproxy_cfg` scripts that use `consul` service discovery.  This is currently not impacting any services in production as none have migrated to consul service discovery yet.


## Why do we need this change?
This change ensures that our local replacement of underscores to dashes for consul service names remains local and does not leak outside of this gem.

#### Dependencies (if any)

:house: [ch47787](https://app.clubhouse.io/movableink/story/47787)
