### PR TITLE
[ch50667] Fix imds token retrieval

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.3.0)
+    MovableInkAWS (2.3.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/metadata.rb
+++ b/lib/movable_ink/aws/metadata.rb
@@ -43,7 +43,7 @@ module MovableInk
       def imds_token(tries: 3)
         tries.times do |num|
           num += 1
-          request = Net::HTTP::Get.new('/latest/api/token')
+          request = Net::HTTP::Put.new('/latest/api/token')
           request['X-aws-ec2-metadata-token-ttl-seconds'] = 120
           response = http(timeout_seconds: num * 3).request(request)
           return response.body

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.3.0'
+    VERSION = '2.3.1'
   end
 end

--- a/spec/aws_spec.rb
+++ b/spec/aws_spec.rb
@@ -23,7 +23,7 @@ describe MovableInk::AWS do
     it 'raises when AWS_REGION is not set and the metadata service is not available' do
       miaws = MovableInk::AWS.new
       # stub an error making a request to the metadata api
-      stub_request(:get, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
       expect { miaws.my_region }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
     end
   end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -10,7 +10,7 @@ describe MovableInk::AWS::EC2 do
     it "should raise an error if trying to load mi_env outside of EC2" do
       aws = MovableInk::AWS.new
       # stub an error making a request to the metadata api
-      stub_request(:get, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
       expect{ aws.mi_env }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
     end
 
@@ -22,7 +22,7 @@ describe MovableInk::AWS::EC2 do
     it "should not find a 'me'" do
       aws = MovableInk::AWS.new
       # stub an error making a request to the metadata api
-      stub_request(:get, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
       expect(aws.me).to eq(nil)
     end
   end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -10,7 +10,7 @@ describe MovableInk::AWS::Metadata do
     it 'should raise an error if the metadata service times out' do
       aws = MovableInk::AWS.new
       # stub an error making a request to the metadata api
-      stub_request(:get, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
       expect{ aws.instance_id }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
       expect{ aws.availability_zone }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
     end
@@ -18,7 +18,7 @@ describe MovableInk::AWS::Metadata do
     it 'should raise an error if trying to load private_ipv4 outside of EC2' do
       aws = MovableInk::AWS.new
       # stub an error making a request to the metadata api
-      stub_request(:get, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
       expect{ aws.private_ipv4 }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
     end
   end


### PR DESCRIPTION
## Current Behavior

Metadata retrieval not working

## Why do we need this change?

I made an unintended change to make it a GET request

:house: [ch50667](https://app.clubhouse.io/movableink/story/50667)
