### PR TITLE
[sc-58967] We dont retry 5xx error exceptions but we should.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.3.2)
+    MovableInkAWS (2.3.3)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -77,6 +77,7 @@ module MovableInk
                Aws::Route53::Errors::ServiceUnavailable,
                Aws::SSM::Errors::TooManyUpdates,
                Aws::SSM::Errors::ThrottlingException,
+               Aws::SSM::Errors::InternalServerError,
                Aws::Athena::Errors::ThrottlingException,
                MovableInk::AWS::Errors::NoEnvironmentTagError
           sleep_time = (num+1)**2 + rand(10)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.3.2'
+    VERSION = '2.3.3'
   end
 end


### PR DESCRIPTION
## Current Behavior

We don't retry 5xx errors from AWS APIs.

## Why do we need this change?

We'd like to retry those.

:house: [ch58967](https://app.clubhouse.io/movableink/story/58967)
