### PR TITLE
[sc-62364] Adding support of dynamic data into AWS lib.

### DIFF
--- a/lib/movable_ink/aws/metadata.rb
+++ b/lib/movable_ink/aws/metadata.rb
@@ -1,4 +1,5 @@
 require 'net/http'
+require 'json'
 
 module MovableInk
   class AWS
@@ -12,10 +13,10 @@ module MovableInk
         end
       end
 
-      def retrieve_metadata(key, tries: 3)
+      def retrieve_data(url, tries: 3)
         tries.times do |num|
           num += 1
-          request = Net::HTTP::Get.new("/latest/meta-data/#{key}")
+          request = Net::HTTP::Get.new(url)
           request['X-aws-ec2-metadata-token'] = imds_token
           response = http(timeout_seconds: num * 3).request(request)
           return response.body
@@ -24,6 +25,20 @@ module MovableInk
         end
 
         raise MovableInk::AWS::Errors::MetadataTimeout
+      end
+
+      def retrieve_metadata(key)
+        retrieve_data("/latest/meta-data/#{key}")
+      end
+
+      def retrieve_dynamicdata(key)
+        retrieve_data("/latest/dynamic/#{key}")
+      end
+
+      def instance_identity_document
+        @instance_identity_document ||= JSON.parse(retrieve_dynamicdata('instance-identity/document'))
+      rescue JSON::ParserError
+        return
       end
 
       def availability_zone

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.5.0'
+    VERSION = '2.5.1'
   end
 end

--- a/spec/metadata_spec.rb
+++ b/spec/metadata_spec.rb
@@ -15,6 +15,19 @@ describe MovableInk::AWS::Metadata do
       expect{ aws.availability_zone }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
     end
 
+    it 'should raise an error if the metadata service times out on getting dynamic data' do
+      aws = MovableInk::AWS.new
+      # stub an error making a request to the metadata api
+      stub_request(:put, 'http://169.254.169.254/latest/api/token').to_raise(Net::OpenTimeout)
+      expect{ aws.instance_identity_document }.to raise_error(MovableInk::AWS::Errors::MetadataTimeout)
+    end
+
+    it 'should return nil if the metadata service returns unparseable dynamic data' do
+      aws = MovableInk::AWS.new
+      expect(aws).to receive(:retrieve_data).with('/latest/dynamic/instance-identity/document').and_return("something")
+      expect(aws.instance_identity_document).to eq(nil)
+    end
+
     it 'should raise an error if trying to load private_ipv4 outside of EC2' do
       aws = MovableInk::AWS.new
       # stub an error making a request to the metadata api


### PR DESCRIPTION
## Current Behavior

MovableInk::AWS doesn't support EC2 dynamic data: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-dynamic-data-retrieval.html

## Why do we need this change?

In order to make termination handler working in EU, we need to provide proper credentials to autoscaling scripts to allow instances in EU to manage route53 and cloudwatch alarms in US. This functionality is going to be based on getting account id from instance identity document (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html).

## Implementation Details

Using of dynamic data will allow not to call `sts:GetCallerIdentity` every time when termination handler scripts are executed, instead cached dynamic data will be used.

#### Dependencies (if any)


:house: [sc-62364](https://app.shortcut.com/movableink/story/62364)
