### PR TITLE
[sc-57027] Errno::ECONNREFUSED for EC2 metadata should be retried.

### DIFF
--- a/lib/movable_ink/aws/metadata.rb
+++ b/lib/movable_ink/aws/metadata.rb
@@ -20,7 +20,7 @@ module MovableInk
           request['X-aws-ec2-metadata-token'] = imds_token
           response = http(timeout_seconds: num * 3).request(request)
           return response.body
-        rescue Net::OpenTimeout, Net::ReadTimeout, Errno::EHOSTDOWN
+        rescue Net::OpenTimeout, Net::ReadTimeout, Errno::EHOSTDOWN, Errno::ECONNREFUSED
           sleep(num * 2)
         end
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.5.1'
+    VERSION = '2.5.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

`Errno::ECONNREFUSED` for imdsv2 isn't retried so deploy scripts fail on single failed request to imdsv2.

## Why do we need this change?

We'd like to let imdsv2 have uptime less than 100%.

## Implementation Details



#### Dependencies (if any)


:house: [sc-62709](https://app.shortcut.com/movableink/story/62709)
