### PR TITLE
Ndoubleday/ssmregions

### DIFF
--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,12 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client
-        @ssm_client ||= Aws::SSM::Client.new(region: 'us-east-1')
+      def ssm_client(region = "us-east-1")
+        @ssm_client = Aws::SSM::Client.new(region: "#{region}")
       end
 
-      def ssm_client_failover
-        @ssm_client_failover ||= Aws::SSM::Client.new(region: 'us-west-2')
+      def ssm_client_failover(failregion = "us-west-2")
+        @ssm_client_failover = Aws::SSM::Client.new(region: "#{failregion}")
       end
 
       def run_with_backoff_and_client_fallback(&block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,12 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client(region = "us-east-1")
-        @ssm_client ||= Aws::SSM::Client.new(region: "#{region}")
+      def ssm_client(region = nil)
+        @ssm_client ||= (client) ? client : Aws::SSM::Client.new(region: 'us-east-1')
       end
 
-      def ssm_client_failover(failregion = "us-west-2")
-        @ssm_client_failover ||= Aws::SSM::Client.new(region: "#{failregion}")
+      def ssm_client_failover(failregion = nil)
+        @ssm_client_failover ||= (client) ? client: Aws::SSM::Client.new(region: 'us-west-2')
       end
 
       def run_with_backoff_and_client_fallback(&block)
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:)
+      def get_secret(environment: mi_env, role:, attribute:,client = nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:)
+      def get_role_secrets(environment: mi_env, role:,client = nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:,client = nil)
+      def get_secret(environment: mi_env, role:, attribute:,region = nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:,client = nil)
+      def get_role_secrets(environment: mi_env, role:,region = nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -4,11 +4,11 @@ module MovableInk
   class AWS
     module SSM
       def ssm_client(region = "us-east-1")
-        @ssm_client = Aws::SSM::Client.new(region: "#{region}")
+        @ssm_client ||= Aws::SSM::Client.new(region: "#{region}")
       end
 
       def ssm_client_failover(failregion = "us-west-2")
-        @ssm_client_failover = Aws::SSM::Client.new(region: "#{failregion}")
+        @ssm_client_failover ||= Aws::SSM::Client.new(region: "#{failregion}")
       end
 
       def run_with_backoff_and_client_fallback(&block)


### PR DESCRIPTION
## Current Behavior

SSM module is currently hard coded to leverage us-east-1 and us-west2

## Why do we need this change?

SSM module should be useful for all regions

## Implementation Details

parameter of method changed to allow var to be passed, and client to leverage whatever region passed as param, or defaulting to us-east-1, with us-west-2 as failover.

#### Dependencies (if any)
N/A 

:house: [sc-62847](https://app.shortcut.com/movableink/story/62847/update-miaws-gem-to-use-local-region-api-for-ssm)
