### PR TITLE
Ndoubleday/ssmregions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.6.0)
+    MovableInkAWS (2.6.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,26 +3,26 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client(region = 'us-east-1')
-        @ssm_client ||= Aws::SSM::Client.new(region: region)
+      def ssm_client(region = "us-east-1")
+        @ssm_client = (region.nil?) ? Aws::SSM::Client.new(region: "us-east-1") : Aws::SSM::Client.new(region: region)
       end
 
-      def ssm_client_failover(failregion = 'us-west-2')
-        @ssm_client_failover ||= Aws::SSM::Client.new(region: failregion)
+      def ssm_client_failover(failregion = "us-west-2")
+        @ssm_client_failover = (failregion.nil?) ? Aws::SSM::Client.new(region: "us-west-2") : Aws::SSM::Client.new(region: failregion)
       end
 
-      def run_with_backoff_and_client_fallback(&block)
+      def run_with_backoff_and_client_fallback(region = nil, failregion = nil, &block)
         run_with_backoff do
-          block.call(ssm_client)
+          block.call(ssm_client(region))
         end
       rescue MovableInk::AWS::Errors::FailedWithBackoff => e
         run_with_backoff(tries: 3) do
-          block.call(ssm_client_failover)
+          block.call(ssm_client_failover(failregion))
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:, region: nil)
-        run_with_backoff_and_client_fallback do |ssm|
+      def get_secret(environment: mi_env, role:, attribute:, region: nil, failregion: nil)
+        run_with_backoff_and_client_fallback(region, failregion) do |ssm|
           begin
             resp = ssm.get_parameter(
                       name: "/#{environment}/#{role}/#{attribute}",
@@ -35,9 +35,9 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:, region: nil)
+      def get_role_secrets(environment: mi_env, role:, region: nil, failregion: nil)
         path = "/#{environment}/#{role}"
-        run_with_backoff_and_client_fallback do |ssm|
+        run_with_backoff_and_client_fallback(region, failregion) do |ssm|
           ssm.get_parameters_by_path(
             path: path,
             with_decryption: true

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,11 +3,11 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client(region = "us-east-1")
+      def ssm_client(region = nil)
         @ssm_client = (region.nil?) ? Aws::SSM::Client.new(region: "us-east-1") : Aws::SSM::Client.new(region: region)
       end
 
-      def ssm_client_failover(failregion = "us-west-2")
+      def ssm_client_failover(failregion = nil)
         @ssm_client_failover = (failregion.nil?) ? Aws::SSM::Client.new(region: "us-west-2") : Aws::SSM::Client.new(region: failregion)
       end
 

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,12 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client
-        @ssm_client ||= Aws::SSM::Client.new(region: 'us-east-1')
+      def ssm_client(region = "us-east-1")
+        @ssm_client = Aws::SSM::Client.new(region: "#{region}")
       end
 
-      def ssm_client_failover
-        @ssm_client_failover ||= Aws::SSM::Client.new(region: 'us-west-2')
+      def ssm_client_failover(failregion = "us-west-2")
+        @ssm_client_failover = Aws::SSM::Client.new(region: "#{failregion}")
       end
 
       def run_with_backoff_and_client_fallback(&block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -4,11 +4,11 @@ module MovableInk
   class AWS
     module SSM
       def ssm_client(region = nil)
-        @ssm_client ||= (client) ? client : Aws::SSM::Client.new(region: 'us-east-1')
+        @ssm_client ||= (region) ? region : Aws::SSM::Client.new(region: 'us-east-1')
       end
 
       def ssm_client_failover(failregion = nil)
-        @ssm_client_failover ||= (client) ? client: Aws::SSM::Client.new(region: 'us-west-2')
+        @ssm_client_failover ||= (failregion) ? failregion: Aws::SSM::Client.new(region: 'us-west-2')
       end
 
       def run_with_backoff_and_client_fallback(&block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,12 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client(region = nil)
-        @ssm_client ||= (region) ? region : Aws::SSM::Client.new(region: 'us-east-1')
+      def ssm_client(region = 'us-east-1')
+        @ssm_client ||= Aws::SSM::Client.new(region: region)
       end
 
-      def ssm_client_failover(failregion = nil)
-        @ssm_client_failover ||= (failregion) ? failregion: Aws::SSM::Client.new(region: 'us-west-2')
+      def ssm_client_failover(failregion = 'us-west-2')
+        @ssm_client_failover ||= Aws::SSM::Client.new(region: failregion)
       end
 
       def run_with_backoff_and_client_fallback(&block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,15 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
+
       def ssm_client(region = nil)
-        @ssm_client = (region.nil?) ? Aws::SSM::Client.new(region: "us-east-1") : Aws::SSM::Client.new(region: region)
+        @ssm_clients_map ||= {}
+        @ssm_clients_map[region] ||= Aws::SSM::Client.new(region: (region.nil?) ? 'us-east-1' : region)
       end
 
       def ssm_client_failover(failregion = nil)
-        @ssm_client_failover = (failregion.nil?) ? Aws::SSM::Client.new(region: "us-west-2") : Aws::SSM::Client.new(region: failregion)
+        @ssm_failover_clients_map ||= {}
+        @ssm_failover_clients_map[failregion] ||= Aws::SSM::Client.new(region: (failregion.nil?) ? 'us-west-2' : failregion)
       end
 
       def run_with_backoff_and_client_fallback(region = nil, failregion = nil, &block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -3,12 +3,12 @@ require 'aws-sdk-ssm'
 module MovableInk
   class AWS
     module SSM
-      def ssm_client(region = "us-east-1")
-        @ssm_client ||= Aws::SSM::Client.new(region: "#{region}")
+      def ssm_client(region = nil)
+        @ssm_client ||= (client) ? client : Aws::SSM::Client.new(region: 'us-east-1')
       end
 
-      def ssm_client_failover(failregion = "us-west-2")
-        @ssm_client_failover ||= Aws::SSM::Client.new(region: "#{failregion}")
+      def ssm_client_failover(failregion = nil)
+        @ssm_client_failover ||= (client) ? client: Aws::SSM::Client.new(region: 'us-west-2')
       end
 
       def run_with_backoff_and_client_fallback(&block)
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:)
+      def get_secret(environment: mi_env, role:, attribute:,client = nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:)
+      def get_role_secrets(environment: mi_env, role:,client = nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:,client = nil)
+      def get_secret(environment: mi_env, role:, attribute:,region = nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:,client = nil)
+      def get_role_secrets(environment: mi_env, role:,region = nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -4,11 +4,11 @@ module MovableInk
   class AWS
     module SSM
       def ssm_client(region = "us-east-1")
-        @ssm_client = Aws::SSM::Client.new(region: "#{region}")
+        @ssm_client ||= Aws::SSM::Client.new(region: "#{region}")
       end
 
       def ssm_client_failover(failregion = "us-west-2")
-        @ssm_client_failover = Aws::SSM::Client.new(region: "#{failregion}")
+        @ssm_client_failover ||= Aws::SSM::Client.new(region: "#{failregion}")
       end
 
       def run_with_backoff_and_client_fallback(&block)

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:,region = nil)
+      def get_secret(environment: mi_env, role:, attribute:,region: nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:,region = nil)
+      def get_role_secrets(environment: mi_env, role:,region: nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/aws/ssm.rb
+++ b/lib/movable_ink/aws/ssm.rb
@@ -21,7 +21,7 @@ module MovableInk
         end
       end
 
-      def get_secret(environment: mi_env, role:, attribute:,region: nil)
+      def get_secret(environment: mi_env, role:, attribute:, region: nil)
         run_with_backoff_and_client_fallback do |ssm|
           begin
             resp = ssm.get_parameter(
@@ -35,7 +35,7 @@ module MovableInk
         end
       end
 
-      def get_role_secrets(environment: mi_env, role:,region: nil)
+      def get_role_secrets(environment: mi_env, role:, region: nil)
         path = "/#{environment}/#{role}"
         run_with_backoff_and_client_fallback do |ssm|
           ssm.get_parameters_by_path(

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.6.0'
+    VERSION = '2.6.1'
   end
 end

--- a/spec/ssm_spec.rb
+++ b/spec/ssm_spec.rb
@@ -68,12 +68,22 @@ describe MovableInk::AWS::SSM do
       expect(Aws::SSM::Client).to receive(:new).with({ region: 'us-east-1' })
       aws.ssm_client
     end
+
+    it 'Allows region to be defined as a parameter' do
+      expect(Aws::SSM::Client).to receive(:new).with({ region: 'us-east-2' })
+      aws.ssm_client('us-east-2')
+    end
   end
 
   describe 'ssm_client_failover' do
     it 'fails over to us-west-2' do
       expect(Aws::SSM::Client).to receive(:new).with({ region: 'us-west-2' })
       aws.ssm_client_failover
+    end
+
+    it 'fails over to parameter defined region' do
+      expect(Aws::SSM::Client).to receive(:new).with({ region: 'us-west-1' })
+      aws.ssm_client_failover('us-west-1')
     end
   end
 


### PR DESCRIPTION
## Current Behavior
regions are hard coded without ability to pass params to change


## Why do we need this change?

We're growing into new regions that existing code doesn't cover

## Implementation Details

changed logic to allow for optional region to be defined

#### Dependencies (if any)


:house: [sc-62847](https://app.shortcut.com/movableink/story/62847/)