### PR TITLE
Add IAM rate throttling errer [sc-64139]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.6.1)
+    MovableInkAWS (2.6.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       aws-sdk-ec2 (~> 1)
       aws-sdk-eks (~> 1)
       aws-sdk-elasticache (~> 1)
+      aws-sdk-iam (~> 1)
       aws-sdk-rds (~> 1)
       aws-sdk-route53 (~> 1)
       aws-sdk-s3 (~> 1)
@@ -46,6 +47,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-elasticache (1.76.0)
+      aws-sdk-core (~> 3, >= 3.127.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-iam (1.68.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-kms (1.55.0)
@@ -117,4 +121,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.1.4
+   2.3.11

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-ec2', '~> 1'
   s.add_runtime_dependency 'aws-sdk-eks', '~> 1'
   s.add_runtime_dependency 'aws-sdk-elasticache', '~> 1'
+  s.add_runtime_dependency 'aws-sdk-iam', '~> 1'
   s.add_runtime_dependency 'aws-sdk-rds', '~> 1'
   s.add_runtime_dependency 'aws-sdk-route53', '~> 1'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1'

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -84,7 +84,8 @@ module MovableInk
                Aws::SSM::Errors::Http503Error,
                Aws::SSM::Errors::Http502Error,
                Aws::Athena::Errors::ThrottlingException,
-               MovableInk::AWS::Errors::NoEnvironmentTagError
+               MovableInk::AWS::Errors::NoEnvironmentTagError,
+               Aws::IAM::Errors::Throttling
           sleep_time = (num+1)**2 + rand(10)
           if quiet
             (num >= tries - 1) ? notify_and_sleep(sleep_time, $!.class) : sleep(sleep_time)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -12,6 +12,7 @@ require_relative 'aws/elasticache'
 require_relative 'aws/api_gateway'
 require_relative 'consul/consul'
 require 'aws-sdk-cloudwatch'
+require 'aws-sdk-iam'
 
 
 module MovableInk
@@ -85,6 +86,8 @@ module MovableInk
                Aws::SSM::Errors::Http502Error,
                Aws::Athena::Errors::ThrottlingException,
                MovableInk::AWS::Errors::NoEnvironmentTagError,
+               Aws::IAM::Errors::LimitExceededException,
+               Aws::IAM::Errors::RequestLimitExceeded,
                Aws::IAM::Errors::Throttling
           sleep_time = (num+1)**2 + rand(10)
           if quiet

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.6.1'
+    VERSION = '2.6.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

The IAM Rate Throttling is not included in the backoff retry method.

## Why do we need this change?

We are sometimes seeing issues with IAM API rate limiting, so we would like to add in this change to account for it.

## Implementation Details



#### Dependencies (if any)


:house: [sc-64139](https://app.shortcut.com/movableink/story/64139)
