### PR TITLE
[sc-65791] Backward compatible credentials param for api gateway

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.6.3)
+    MovableInkAWS (2.6.4)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/api_gateway.rb
+++ b/lib/movable_ink/aws/api_gateway.rb
@@ -5,8 +5,8 @@ require 'httparty'
 module MovableInk
   class AWS
     module ApiGateway
-      def post_signed_gateway_request(gateway_url:, region:, body:)
-        credentials = Aws::CredentialProviderChain.new.resolve.credentials
+      def post_signed_gateway_request(gateway_url:, region:, body:, credentials: nil)
+        credentials = (credentials) ? credentials : Aws::CredentialProviderChain.new.resolve.credentials
 
         signer = Aws::Sigv4::Signer.new({
           service: 'execute-api',

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.6.3'
+    VERSION = '2.6.4'
   end
 end


### PR DESCRIPTION
## Current Behavior

Credentials for API Gateway request are always taken from caller so there's no way to use custom creds.

## Why do we need this change?

We need to be able to send request to API Gateway hosted in one AWS account using user's credentials for different AWS account.

## Implementation Details

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Sigv4/Signer.html


#### Dependencies (if any)
`-`

:house: [sc-65791](https://app.shortcut.com/movableink/story/65791)
