### PR TITLE
Add par datacenter [sc-65349]

### DIFF
--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -36,7 +36,8 @@ module MovableInk
           'rld' => 'us-west-2',
           'dub' => 'eu-west-1',
           'ord' => 'us-east-2',
-          'fra' => 'eu-central-1'
+          'fra' => 'eu-central-1',
+          'par' => 'eu-west-3'
         }
       end
     end


### PR DESCRIPTION
## Current Behavior

There is no `par` datacenter in the config.

## Why do we need this change?

Allows provisioning repo to launch instances with the `par` datacenter field.

## Implementation Details



