### PR TITLE
Bump awslib version [sc-65349]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.6.3)
+    MovableInkAWS (2.6.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.6.3'
+    VERSION = '2.6.5'
   end
 end


### PR DESCRIPTION
## Current Behavior

Fixing my last PR. This bumps the awslib version to the next one.

## Why do we need this change?

Allows the library to be published properly.

## Implementation Details

(bumping by .2, because I pushed a `v2.6.4` tag, so this new one is clean)