### PR TITLE
[sc-66750] run_with_backoff should allow to suppress exceptions by class and message pattern

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.1)
+    MovableInkAWS (2.7.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/errors.rb
+++ b/lib/movable_ink/aws/errors.rb
@@ -8,6 +8,21 @@ module MovableInk
       class InvalidDiscoveryTypeError < StandardError; end
       class RoleNameRequiredError < StandardError; end
       class RoleNameInvalidError < StandardError; end
+
+      class ExpectedError
+        def initialize(error_class, message_patterns = [])
+          @error_class = error_class
+          message_patterns.each { |pattern| raise StandardError.new("Invalid message pattern provided #{pattern.inspect}") unless pattern.class == Regexp }
+          @message_patterns = message_patterns
+        end
+
+        def match?(exception)
+          return false unless exception.class == @error_class
+          return true if @message_patterns.length == 0
+          @message_patterns.each {|pattern| return true if exception.message.match(pattern) }
+          false
+        end
+      end
     end
   end
 end

--- a/lib/movable_ink/aws/route53.rb
+++ b/lib/movable_ink/aws/route53.rb
@@ -16,7 +16,7 @@ module MovableInk
         resource_record_sets(zone, client).select{|rrs| rrs.set_identifier == instance_name}.map(&:to_h)
       end
 
-      def delete_resource_record_sets(zone, instance_name, client = nil)
+      def delete_resource_record_sets(zone, instance_name, client = nil, expected_errors = [])
         resource_record_sets = get_resource_record_sets_by_instance_name(zone, instance_name, client)
         return if resource_record_sets.empty?
 
@@ -29,7 +29,7 @@ module MovableInk
           }
         }
 
-        run_with_backoff do
+        run_with_backoff(expected_errors: expected_errors) do
           route53(client).change_resource_record_sets({change_batch: change_batch, hosted_zone_id: zone})
         end
       end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.1'
+    VERSION = '2.7.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

`run_with_backoff` will generate `Unhandled AWS Exception` message if AWS call fails with some error like `Aws::Route53::Errors::InvalidChangeBatch` with message `[Tried to delete resource record set [name='node.us-east-2c.sorcerer.movableink-templates.com.', type='A', set-identifier='10_2_2_254', health check='7c09e3dd-a380-4700-ac59-1513e799cd5e'] but it was not found]`. 

## Why do we need this change?

In some cases we'd like to control what exceptions can be skipped w/o throwing `Unhandled AWS Exception` .

:house: [sc-66750](https://app.shortcut.com/movableink/story/66750)
