### PR TITLE
[sc-67849] Tests for MovableInk::AWS::Errors + removed addressable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.2)
+    MovableInkAWS (2.7.3)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.7.0)
+    addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.605.0)
@@ -73,8 +73,8 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.5)
+      rexml
     deep_merge (1.2.2)
     diff-lcs (1.3)
     diplomat (2.4.2)
@@ -82,7 +82,7 @@ GEM
       faraday (>= 0.9, < 1.1.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
-    hashdiff (1.0.0)
+    hashdiff (1.0.1)
     httparty (0.16.3)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -92,7 +92,8 @@ GEM
     mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
-    public_suffix (4.0.5)
+    public_suffix (4.0.7)
+    rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -106,9 +107,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
-    safe_yaml (1.0.5)
-    webmock (3.7.6)
-      addressable (>= 2.3.6)
+    webmock (3.17.1)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
@@ -121,4 +121,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.14
+   2.3.11

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.2'
+    VERSION = '2.7.3'
   end
 end

--- a/spec/errors_spec.rb
+++ b/spec/errors_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../lib/movable_ink/aws'
+require 'webmock/rspec'
+
+describe MovableInk::AWS::Errors do
+  context 'ExpectedError' do
+    it 'matches exception by class name and pattern' do
+      expected = MovableInk::AWS::Errors::ExpectedError.new(Aws::Errors::ServiceError, [/something failed/])
+      expect(expected.match?(Aws::Errors::ServiceError.new(nil, 'There\'s something failed.'))).to eq(true)
+    end
+
+    it 'matches exception by class name only' do
+      expected = MovableInk::AWS::Errors::ExpectedError.new(Aws::Errors::ServiceError)
+      expect(expected.match?(Aws::Errors::ServiceError.new(nil, 'There\'s something failed.'))).to eq(true)
+    end
+
+    it 'matches exception by class name only - negative match' do
+      expected = MovableInk::AWS::Errors::ExpectedError.new(Aws::IAM::Errors::Throttling)
+      expect(expected.match?(Aws::Errors::ServiceError.new(nil, 'There\'s something failed.'))).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
## Why do we need this change?

1. No tests for `MovableInk::AWS::Errors::ExpectedError` class.
2. Dependency vulnerability alert triggered for `addressable` gem: https://github.com/movableink/awslib/security/dependabot/1

P.S. `addressable` is not explicitly used in runtime, only as a dependency.

:house: [sc-67849](https://app.shortcut.com/movableink/story/67849)
