### PR TITLE
[sc-67849] Retries for Aws::AutoScaling::Errors::InternalFailure

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.3)
+    MovableInkAWS (2.7.4)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -76,6 +76,7 @@ module MovableInk
                Aws::SNS::Errors::Throttling,
                Aws::AutoScaling::Errors::Throttling,
                Aws::AutoScaling::Errors::ThrottledException,
+               Aws::AutoScaling::Errors::InternalFailure,
                Aws::S3::Errors::SlowDown,
                Aws::Route53::Errors::Throttling,
                Aws::Route53::Errors::ThrottlingException,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.3'
+    VERSION = '2.7.4'
   end
 end


### PR DESCRIPTION
## Current Behavior

<img width="1390" alt="Screen Shot 2022-08-29 at 14 58 49" src="https://user-images.githubusercontent.com/14876304/187277472-48bd21ee-86b9-4857-b6c2-9010b99042e7.png">

## Why do we need this change?

Hunting down the last `Unhandled AWS API Error` errors thrown by AWSlib -- `Aws::AutoScaling::Errors::InternalFailure` is legit to retry.

## Implementation Details



#### Dependencies (if any)


:house: [sc-67849](https://app.shortcut.com/movableink/story/67849)
