### PR TITLE
[sc-69623] EC2 client override for all_instances()

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.4)
+    MovableInkAWS (2.7.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -4,9 +4,9 @@ require 'diplomat'
 module MovableInk
   class AWS
     module EC2
-      def ec2(region: my_region)
+      def ec2(region: my_region, client: nil)
         @ec2_client ||= {}
-        @ec2_client[region] ||= Aws::EC2::Client.new(region: region)
+        @ec2_client[region] ||= (client) ? client : Aws::EC2::Client.new(region: region)
       end
 
       def mi_env_cache_file_path
@@ -38,9 +38,9 @@ module MovableInk
         end
       end
 
-      def all_instances(region: my_region, no_filter: false)
+      def all_instances(region: my_region, no_filter: false, client: nil)
         @all_instances ||= {}
-        @all_instances[region] ||= load_all_instances(region, no_filter: no_filter)
+        @all_instances[region] ||= load_all_instances(region, no_filter: no_filter, client: client)
       end
 
       def default_filter
@@ -54,11 +54,11 @@ module MovableInk
         }]
       end
 
-      def load_all_instances(region, no_filter: false, filter: nil)
+      def load_all_instances(region, no_filter: false, filter: nil, client: nil)
         filters = no_filter ? nil : (filter || default_filter)
 
         run_with_backoff do
-          ec2(region: region).describe_instances(filters: filters).flat_map do |resp|
+          ec2(region: region, client: client).describe_instances(filters: filters).flat_map do |resp|
             resp.reservations.flat_map(&:instances)
           end
         end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.4'
+    VERSION = '2.7.5'
   end
 end


### PR DESCRIPTION
## Current Behavior

There's no way to override ec2 client when getting full list of EC2 instances with `all_instances()` method.

## Why do we need this change?

We'd like to use `all_instances()` for different AWS accounts/regions.

:house: [sc-69623](https://app.shortcut.com/movableink/story/69623)
