### PR TITLE
[sc-69282] Optional list of AZs for redis_by_role method.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.5)
+    MovableInkAWS (2.7.6)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/errors.rb
+++ b/lib/movable_ink/aws/errors.rb
@@ -8,6 +8,7 @@ module MovableInk
       class InvalidDiscoveryTypeError < StandardError; end
       class RoleNameRequiredError < StandardError; end
       class RoleNameInvalidError < StandardError; end
+      class AvailabilityZonesListInvalidError < StandardError; end
 
       class ExpectedError
         def initialize(error_class, message_patterns = [])

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.5'
+    VERSION = '2.7.6'
   end
 end


### PR DESCRIPTION
## Current Behavior

`redis_by_role` always returns redis instances from all AZs.

## Why do we need this change?

We need the way to get list of redis instances from specified AZs if it's needed.

:house: [sc-69282](https://app.shortcut.com/movableink/story/XXXX)
