### PR TITLE
[sc-66962] Pagination for route53 list records, list zones method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,4 @@ gemspec
 group :test do
   gem 'rspec',    '~> 3.6'
   gem 'webmock'
-  gem 'pry'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ gemspec
 group :test do
   gem 'rspec',    '~> 3.6'
   gem 'webmock'
+  gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    coderay (1.1.3)
     crack (0.4.5)
       rexml
     deep_merge (1.2.2)
@@ -88,15 +87,11 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     jmespath (1.6.1)
-    method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
     public_suffix (4.0.7)
     rexml (3.2.5)
     rspec (3.9.0)
@@ -122,7 +117,6 @@ PLATFORMS
 
 DEPENDENCIES
   MovableInkAWS!
-  pry
   rspec (~> 3.6)
   webmock
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.7.6)
+    MovableInkAWS (2.8.0)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -73,6 +73,7 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.5.0)
       aws-eventstream (~> 1, >= 1.0.2)
+    coderay (1.1.3)
     crack (0.4.5)
       rexml
     deep_merge (1.2.2)
@@ -87,11 +88,15 @@ GEM
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
     jmespath (1.6.1)
+    method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
     multipart-post (2.2.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.7)
     rexml (3.2.5)
     rspec (3.9.0)
@@ -117,6 +122,7 @@ PLATFORMS
 
 DEPENDENCIES
   MovableInkAWS!
+  pry
   rspec (~> 3.6)
   webmock
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.7.6'
+    VERSION = '2.8.0'
   end
 end


### PR DESCRIPTION
## Why do we need this change?

1. AWS lib doesn't support listing route53 zones.
2. There's no pagination for listing records.

:house: [sc-66962](https://app.shortcut.com/movableink/story/66962)
