### PR TITLE
Fix elastic ip verification

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.0)
+    MovableInkAWS (2.8.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -256,13 +256,13 @@ module MovableInk
         end
       end
 
-      def verify_elastic_ip_address(public_ip:)
+      def elastic_ip_address_exist?(public_ip:)
         expected_errors = [
           MovableInk::AWS::Errors::ExpectedError.new(Aws::EC2::Errors::InvalidAddressNotFound, [/Address \'#{public_ip}\' not found./])
         ]
         begin
           run_with_backoff(expected_errors: expected_errors) do
-            result = ec2.describe_addresses({
+            ec2.describe_addresses({
               public_ips: [public_ip]
             })
             return true

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -255,6 +255,28 @@ module MovableInk
           })
         end
       end
+
+      def verify_elastic_ip_address(public_ip:)
+        begin
+          run_with_backoff do
+            result = ec2.describe_addresses({
+              public_ips: [public_ip]
+            })
+            if result.respond_to?(:addresses)
+              if result.addresses.length > 0
+                return true
+              else
+                return false
+              end
+            else
+              return false
+            end
+          end
+        rescue Aws::EC2::Errors::InvalidAddressNotFound
+          return false
+        end
+        return false
+      end
     end
   end
 end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.0'
+    VERSION = '2.8.1'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -740,7 +740,7 @@ describe MovableInk::AWS::EC2 do
       end
   
       it 'will return false when there is no elastic IP' do
-        ec2.stub_responses(:describe_addresses, empty_public_ip_data)
+        ec2.stub_responses(:describe_addresses, MovableInk::AWS::Errors::ServiceError.new("Aws::EC2::Errors::InvalidAddressNotFound: Address \'185.35.3.4\' not found."))
         allow(aws).to receive(:my_region).and_return('us-east-2')
         allow(aws).to receive(:public_ip).and_return('185.35.3.4')
         allow(aws).to receive(:ec2).and_return(ec2)

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -736,7 +736,7 @@ describe MovableInk::AWS::EC2 do
         allow(aws).to receive(:my_region).and_return('us-east-2')
         allow(aws).to receive(:public_ip).and_return('185.35.3.4')
         allow(aws).to receive(:ec2).and_return(ec2)
-        expect(aws.verify_elastic_ip_address(public_ip: '185.35.3.4')).to eq(true)
+        expect(aws.elastic_ip_address_exist?(public_ip: '185.35.3.4')).to eq(true)
       end
   
       it 'will return false when there is no elastic IP' do
@@ -744,7 +744,7 @@ describe MovableInk::AWS::EC2 do
         allow(aws).to receive(:my_region).and_return('us-east-2')
         allow(aws).to receive(:public_ip).and_return('185.35.3.4')
         allow(aws).to receive(:ec2).and_return(ec2)
-        expect(aws.verify_elastic_ip_address(public_ip: '185.35.3.4')).to eq(false)
+        expect(aws.elastic_ip_address_exist?(public_ip: '185.35.3.4')).to eq(false)
       end
     end
   end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -718,5 +718,34 @@ describe MovableInk::AWS::EC2 do
         expect(aws.assign_ip_address(role: 'some_role').association_id).to eq('eipassoc-3')
       end
     end
+    
+    context 'elastic ips' do
+      let(:public_ip_data) {ec2.stub_data(:describe_addresses, addresses: [
+          {
+            allocation_id: "eipalloc-12345678",
+            association_id: "eipassoc-12345678",
+            public_ip: "185.35.4.3", 
+          }
+        ])
+      }
+
+      let(:empty_public_ip_data) {ec2.stub_data(:describe_addresses, addresses: [])}
+
+      it 'will return true when there is an elastic IP' do
+        ec2.stub_responses(:describe_addresses, public_ip_data)
+        allow(aws).to receive(:my_region).and_return('us-east-2')
+        allow(aws).to receive(:public_ip).and_return('185.35.3.4')
+        allow(aws).to receive(:ec2).and_return(ec2)
+        expect(aws.verify_elastic_ip_address(public_ip: '185.35.3.4')).to eq(true)
+      end
+  
+      it 'will return false when there is no elastic IP' do
+        ec2.stub_responses(:describe_addresses, empty_public_ip_data)
+        allow(aws).to receive(:my_region).and_return('us-east-2')
+        allow(aws).to receive(:public_ip).and_return('185.35.3.4')
+        allow(aws).to receive(:ec2).and_return(ec2)
+        expect(aws.verify_elastic_ip_address(public_ip: '185.35.3.4')).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Current Behavior

The method used to check if a public IP address is an elastic IP is returning false positives.


## Why do we need this change?

* This will use the AWS EC2 API to get a definitive result on whether an IP is an elastic IP.

## Implementation Details

* Using the [describe_addresses](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/EC2/Client.html#describe_addresses-instance_method) API call to check
* Returns an error if the address is not an elastic IP
* (draft during code freeze)

#### Dependencies (if any)


:house: [sc-71980](https://app.shortcut.com/movableink/story/71980)
