### PR TITLE
Fix faraday version issue

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,8 @@ on:
     branches: [$default-branch]
 
 jobs:
+  # This test is used to ensure the chef-solo version of ruby (2.5.0)
+  # is able to install miaws successfully.
   test0:
 
     runs-on: ubuntu-18.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,24 @@ on:
     branches: [$default-branch]
 
 jobs:
+  test0:
+
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.5
+
+    - name: Install dependencies
+      run: bundle install --retry=3
+
+    - name: Run tests
+      run: bundle exec rspec spec/
+
   test:
 
     runs-on: ubuntu-18.04

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'faraday', '= 1.10.2'
+
 group :test do
   gem 'rspec',    '~> 3.6'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.2)
+    MovableInkAWS (2.8.3)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -80,10 +80,29 @@ GEM
     diplomat (2.6.4)
       deep_merge (~> 1.2)
       faraday (>= 0.9, < 3.0, != 2.0.0)
-    faraday (2.7.1)
-      faraday-net_http (>= 2.0, < 3.1)
+    faraday (1.10.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.0)
+      faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.2)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.2.0)
+    faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     hashdiff (1.0.1)
     httparty (0.16.3)
       mime-types (~> 3.0)
@@ -93,6 +112,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     multi_xml (0.6.0)
+    multipart-post (2.2.3)
     public_suffix (4.0.7)
     rexml (3.2.5)
     rspec (3.9.0)
@@ -119,6 +139,7 @@ PLATFORMS
 
 DEPENDENCIES
   MovableInkAWS!
+  faraday (= 1.10.2)
   rspec (~> 3.6)
   webmock
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.2'
+    VERSION = '2.8.3'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -445,7 +445,7 @@ describe MovableInk::AWS::EC2 do
             headers: {
             'Accept'=>'*/*',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Faraday v2.7.1'
+            'User-Agent'=>'Faraday v1.10.2'
            }).
          to_return(status: 200, body: json, headers: {})
 
@@ -458,7 +458,7 @@ describe MovableInk::AWS::EC2 do
            headers: {
           'Accept'=>'*/*',
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent'=>'Faraday v2.7.1'
+          'User-Agent'=>'Faraday v1.10.2'
            }).
          to_return(status: 200, body: json, headers: {})
 
@@ -476,7 +476,7 @@ describe MovableInk::AWS::EC2 do
             headers: {
             'Accept'=>'*/*',
             'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'User-Agent'=>'Faraday v2.7.1'
+            'User-Agent'=>'Faraday v1.10.2'
            }).
          to_return(status: 200, body: json, headers: {})
 
@@ -495,7 +495,7 @@ describe MovableInk::AWS::EC2 do
             headers: {
               'Accept'=>'*/*',
               'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-              'User-Agent'=>'Faraday v2.7.1'
+              'User-Agent'=>'Faraday v1.10.2'
             }
           })
           .to_return(status: 200, body: json, headers: {})


### PR DESCRIPTION
## Current Behavior

The `awslib` library uses a package (faraday-net_http v3.0.2) that is not compatible with the ruby 2.5. (We use ruby 2.5 during chef-solo provisioning)

## Why do we need this change?

This allows the provisioning repo to install miaws successfully.

## Implementation Details

* Added a new unit test that verifies ruby v2.5 is able to install this gem.
* This unit test should make it easier to test these out when creating PRs.

#### Dependencies (if any)


:house: [sc-73298](https://app.shortcut.com/movableink/story/73298)
