### PR TITLE
[sc-86059] AWS STS exceptions should be retried.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.4)
+    MovableInkAWS (2.8.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -87,6 +87,8 @@ module MovableInk
                Aws::SSM::Errors::InternalServerError,
                Aws::SSM::Errors::Http503Error,
                Aws::SSM::Errors::Http502Error,
+               Aws::STS::Errors::ServiceUnavailable,
+               Aws::STS::Errors::Throttling,
                Aws::Athena::Errors::ThrottlingException,
                MovableInk::AWS::Errors::NoEnvironmentTagError,
                Aws::IAM::Errors::LimitExceededException,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.4'
+    VERSION = '2.8.5'
   end
 end


### PR DESCRIPTION
## Current Behavior

awslib throws exception w/o retries to STS service is it returns 5xx or 429 status codes.

## Why do we need this change?

We'd like to make awslib to apply backoff retries in case of STS unavailability or throttling.

## Implementation Details



#### Dependencies (if any)


:house: [sc-86059](https://app.shortcut.com/movableink/story/86059)
