### PR TITLE
update github actions os [sc-86059]

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
   # is able to install miaws successfully.
   test0:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
 
   test:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
## Current Behavior

* Github actions for `awslib` are not getting started. The runner perpetually gets stuck

## Why do we need this change?

* This will enable the unit tests to be performed

## Implementation Details

* caused by https://github.com/actions/runner-images/issues/6002 (they stopped supporting bionic for this)
* Updated to use focal

#### Dependencies (if any)


:house: [sc-86059](https://app.shortcut.com/movableink/story/86059)
