### PR TITLE
[sc-89400] Allow toggling the autoscaling lambda

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.5)
+    MovableInkAWS (2.8.6)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -10,6 +10,7 @@ PATH
       aws-sdk-eks (~> 1)
       aws-sdk-elasticache (~> 1)
       aws-sdk-iam (~> 1)
+      aws-sdk-lambda (~> 1)
       aws-sdk-rds (~> 1)
       aws-sdk-route53 (~> 1)
       aws-sdk-s3 (~> 1)
@@ -53,6 +54,9 @@ GEM
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-kms (1.62.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-lambda (1.96.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-rds (1.171.0)

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-eks', '~> 1'
   s.add_runtime_dependency 'aws-sdk-elasticache', '~> 1'
   s.add_runtime_dependency 'aws-sdk-iam', '~> 1'
+  s.add_runtime_dependency 'aws-sdk-lambda', '~> 1'
   s.add_runtime_dependency 'aws-sdk-rds', '~> 1'
   s.add_runtime_dependency 'aws-sdk-route53', '~> 1'
   s.add_runtime_dependency 'aws-sdk-s3', '~> 1'

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -11,6 +11,7 @@ require_relative 'aws/iam'
 require_relative 'aws/eks'
 require_relative 'aws/elasticache'
 require_relative 'aws/api_gateway'
+require_relative 'aws/lambda'
 require_relative 'consul/consul'
 require 'aws-sdk-cloudwatch'
 
@@ -28,6 +29,7 @@ module MovableInk
     include ApiGateway
     include EKS
     include IAM
+    include Lambda
 
     class << self
       def regions

--- a/lib/movable_ink/aws/lambda.rb
+++ b/lib/movable_ink/aws/lambda.rb
@@ -3,7 +3,7 @@ require 'aws-sdk-lambda'
 module MovableInk
   class AWS
     module Lambda
-      def lambda(region: my_region)
+      def lambda(region: 'us-east-1')
         @lambda_client ||= {}
         @lambda_client[region] ||= Aws::Lambda::Client.new(region: region)
       end

--- a/lib/movable_ink/aws/lambda.rb
+++ b/lib/movable_ink/aws/lambda.rb
@@ -1,0 +1,39 @@
+require 'aws-sdk-lambda'
+
+module MovableInk
+  class AWS
+    module Lambda
+      def lambda(region: my_region)
+        @lambda_client ||= {}
+        @lambda_client[region] ||= Aws::Lambda::Client.new(region: region)
+      end
+
+      def disable_autoscaling_lambda
+        function_name = 'autoscaling-scheduled-capacity-production-cleanup'
+
+        lambda.update_function_configuration({
+          function_name: function_name,
+          environment: {
+            variables: {
+              "DRY_RUN" => "true",
+            }
+          }
+        })
+      end
+
+      def enable_autoscaling_lambda
+        function_name = 'autoscaling-scheduled-capacity-production-cleanup'
+
+        lambda.update_function_configuration({
+          function_name: function_name,
+          environment: {
+            variables: {
+              "DRY_RUN" => "false",
+            }
+          }
+        })
+      end
+
+    end
+  end
+end

--- a/lib/movable_ink/aws/lambda.rb
+++ b/lib/movable_ink/aws/lambda.rb
@@ -8,9 +8,7 @@ module MovableInk
         @lambda_client[region] ||= Aws::Lambda::Client.new(region: region)
       end
 
-      def disable_autoscaling_lambda
-        function_name = 'autoscaling-scheduled-capacity-production-cleanup'
-
+      def disable_autoscaling_lambda(function_name)
         lambda.update_function_configuration({
           function_name: function_name,
           environment: {
@@ -21,9 +19,7 @@ module MovableInk
         })
       end
 
-      def enable_autoscaling_lambda
-        function_name = 'autoscaling-scheduled-capacity-production-cleanup'
-
+      def enable_autoscaling_lambda(function_name)
         lambda.update_function_configuration({
           function_name: function_name,
           environment: {

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.5'
+    VERSION = '2.8.6'
   end
 end


### PR DESCRIPTION
## Why do we need this change?
Add functions to toggle autoscaling lambda on and off, to be used in failover script.


## Implementation Details



#### Dependencies (if any)


:house: [sc-89400](https://app.shortcut.com/movableink/story/89400)
