### PR TITLE
[sc-102435] Support lower versions of faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '= 2.8.1'
+gem 'faraday', '< 2.9'
 
 group :test do
   gem 'rspec',    '~> 3.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.7)
+    MovableInkAWS (2.8.8)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -18,14 +18,14 @@ PATH
       aws-sdk-ssm (~> 1)
       aws-sigv4 (~> 1.1)
       diplomat (= 2.6.4)
-      faraday (= 2.8.1)
+      faraday (< 2.9)
       httparty (~> 0.21)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
     aws-eventstream (1.3.0)
     aws-partitions (1.877.0)
     aws-sdk-athena (1.79.0)
@@ -82,7 +82,7 @@ GEM
     crack (0.4.5)
       rexml
     deep_merge (1.2.2)
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     diplomat (2.6.4)
       deep_merge (~> 1.2)
       faraday (>= 0.9, < 3.0, != 2.0.0)
@@ -91,30 +91,30 @@ GEM
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
-    hashdiff (1.0.1)
+    hashdiff (1.1.0)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     jmespath (1.6.2)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
-    public_suffix (4.0.7)
-    rexml (3.2.5)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    public_suffix (5.0.4)
+    rexml (3.2.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
-    webmock (3.17.1)
+    webmock (3.19.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -124,9 +124,9 @@ PLATFORMS
 
 DEPENDENCIES
   MovableInkAWS!
-  faraday (= 2.8.1)
+  faraday (< 2.9)
   rspec (~> 3.6)
   webmock
 
 BUNDLED WITH
-   2.3.11
+   1.17.3

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sigv4', '~> 1.1'
   s.add_runtime_dependency 'httparty',  '~> 0.21'
   s.add_runtime_dependency 'diplomat',  '2.6.4'
-  s.add_runtime_dependency 'faraday',  '2.8.1'
+  s.add_runtime_dependency 'faraday',  '< 2.9'
 
   all_files  = `git ls-files`.split("\n")
   test_files = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.7'
+    VERSION = '2.8.8'
   end
 end


### PR DESCRIPTION
## Why do we need this change?
Pinning version `2.8.1` works fine for installing awslib as a standalone package, but does not work well when awslib is listed as a dependency in other projects. 



## Implementation Details



#### Dependencies (if any)


:house: [sc-102435](https://app.shortcut.com/movableink/story/102435)
