### PR TITLE
[sc-106973] aws-sdk-core version bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.9)
+    MovableInkAWS (2.8.10)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)
@@ -27,7 +27,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     aws-eventstream (1.3.0)
-    aws-partitions (1.877.0)
+    aws-partitions (1.894.0)
     aws-sdk-athena (1.79.0)
       aws-sdk-core (~> 3, >= 3.188.0)
       aws-sigv4 (~> 1.1)
@@ -37,7 +37,7 @@ GEM
     aws-sdk-cloudwatch (1.84.0)
       aws-sdk-core (~> 3, >= 3.188.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.190.1)
+    aws-sdk-core (3.191.3)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.8)

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.9'
+    VERSION = '2.8.10'
   end
 end


### PR DESCRIPTION
## Why do we need this change?

Dealing with dependency issues, need to bump up awslib version with newest aws-sdk-core

## Implementation Details



#### Dependencies (if any)


:house: [sc-106973](https://app.shortcut.com/movableink/story/106973)
