### PR TITLE
[sc-107098] Added method to list entries in managed prefix list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.8.10)
+    MovableInkAWS (2.8.11)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -273,6 +273,18 @@ module MovableInk
         # returns false if it ran out of API retries
         return false
       end
+
+      def get_managed_prefix_list_entries(managed_prefix_list_name)
+        entries = []
+        run_with_backoff do
+          result = ec2.describe_managed_prefix_lists({filters: [{name: "prefix-list-name", values: [managed_prefix_list_name]}]})
+          raise MovableInk::AWS::Errors::ServiceError if result.prefix_lists.nil? || result.prefix_lists[0].nil?
+          prefix_list_id = result.prefix_lists[0].prefix_list_id
+          result = ec2.get_managed_prefix_list_entries({prefix_list_id: prefix_list_id})
+          entries = result.data.entries.map {|e| e.cidr}
+        end
+        return entries
+      end
     end
   end
 end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.8.10'
+    VERSION = '2.8.11'
   end
 end


### PR DESCRIPTION
## Why do we need this change?

We need to get list of CIDRs from route53 health checks managed prefix list.

## Implementation Details



#### Dependencies (if any)


:house: [sc-107098](https://app.shortcut.com/movableink/story/107098)
