### PR TITLE
[sc-142660] Update Pull Request Template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@
 #### Dependencies (if any)
 
 
-:card-index: [sc-XXXX]
+:card_index: [sc-XXXX]

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@
 #### Dependencies (if any)
 
 
-:house: [sc-XXXX](https://app.shortcut.com/movableink/story/XXXX)
+:card-index: [sc-XXXX]


### PR DESCRIPTION
## Current Behavior
The shortcut link in the pull request template is a full markdown link.

## Why do we need this change?
We have implemented autolink references on all repositories in the organization. This change will improve the ergonomics of the pull request template by removing the unnecessary additional markdown link. It also will change the :house: emoji to :card-index: if the emoji is being used, both to better represent shortcut cards (instead of clubhouse) and to make it visually clear that this repo has updated to the new template.

## Implementation Details
This pull request has been generated en masse with most other repositories in the organization that have a template. I will do my best to keep up with all of these requests, feel free to ask any questions in the PR itself or to ping me or studio SRE on slack. If this PR has been clogging up your repo for a while, please feel free to ping me to make sure I haven't lost track of it.

:house: [sc-142660]