### PR TITLE
add instance retries [sc-158878]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.9.1)
+    MovableInkAWS (2.9.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -75,6 +75,7 @@ module MovableInk
                Aws::EC2::Errors::InternalError,
                Aws::EC2::Errors::Http503Error,
                Aws::EKS::Errors::TooManyRequestsException,
+               Aws::Errors::MissingCredentialsError,
                Aws::SNS::Errors::ThrottledException,
                Aws::SNS::Errors::Throttling,
                Aws::AutoScaling::Errors::Throttling,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.9.1'
+    VERSION = '2.9.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

* There are occasionally errors when running the termination handler script:

```
Uncaught exception draining instance Aws::Errors::MissingCredentialsError: unable to sign request without credentials set.
```

## Why do we need this change?

* This will add automatic re-tries to the termination handler.

## Implementation Details

* There is an explicit way to do this with the `ec2` client, but it only works when using the instance profile credentials which is not always the case when using `miaws`. https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/InstanceProfileCredentials.html 

```
instance_credentials = Aws::InstanceProfileCredentials.new
ec2 = Aws::EC2::Client.new(credentials: instance_credentials, retries: 5)
```

This can be tested in a future PR if we keep seeing this error.

#### Dependencies (if any)


:card_index: [sc-158878]
