### PR TITLE
add explicit retries [sc-158878]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.9.2)
+    MovableInkAWS (2.9.3)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws.rb
+++ b/lib/movable_ink/aws.rb
@@ -75,7 +75,6 @@ module MovableInk
                Aws::EC2::Errors::InternalError,
                Aws::EC2::Errors::Http503Error,
                Aws::EKS::Errors::TooManyRequestsException,
-               Aws::Errors::MissingCredentialsError,
                Aws::SNS::Errors::ThrottledException,
                Aws::SNS::Errors::Throttling,
                Aws::AutoScaling::Errors::Throttling,

--- a/lib/movable_ink/aws/autoscaling.rb
+++ b/lib/movable_ink/aws/autoscaling.rb
@@ -46,6 +46,20 @@ module MovableInk
         end
       end
 
+      def delete_role_tag_with_retries(role:)
+        run_with_backoff do
+          ec2_with_retries.delete_tags({
+            resources: [instance_id],
+            tags: [
+              {
+                key: "mi:roles",
+                value: role
+              }
+            ]
+          })
+        end
+      end
+
       def complete_lifecycle_action(lifecycle_hook_name:, auto_scaling_group_name:, lifecycle_action_token: nil, instance_id: nil)
         raise ArgumentError.new('lifecycle_action_token or instance_id required') if lifecycle_action_token.nil? && instance_id.nil?
 

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -10,6 +10,16 @@ module MovableInk
         @ec2_client[region] ||= (client) ? client : Aws::EC2::Client.new(region: region)
       end
 
+      def ec2_with_retries(region: my_region, client: nil)
+        @ec2_client_with_retries ||= {}
+        if (client)
+          @ec2_client_with_retries[region] ||= client
+        else
+          instance_credentials = Aws::InstanceProfileCredentials.new
+          @ec2_client_with_retries[region] ||= Aws::EC2::Client.new(region: region, credentials: instance_credentials, retries: 5)
+        end
+      end
+
       def mi_env_cache_file_path
         '/etc/movableink/environments.json'
       end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.9.2'
+    VERSION = '2.9.3'
   end
 end


### PR DESCRIPTION
## Current Behavior

* The `Aws::Errors::MissingCredentialsError` error that I tried to use exponentially back-off retries did not work in the last PR. It just returns this error and does not do the proper retries:

```
Throttled by AWS. Sleeping 6 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 13 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 16 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 22 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 33 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 45 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 49 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 67 seconds, (Aws::Errors::MissingCredentialsError)
Throttled by AWS. Sleeping 81 seconds, (Aws::Errors::MissingCredentialsError)
```

## Why do we need this change?

* This will use the retry credentials functionality that is built-in to the ruby sdk: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/InstanceProfileCredentials.html

## Implementation Details

* There is some code duplication here, but this can be fixed in a future PR. These changes are hard to test before merging, so trying to decrease the blast radius of the change.
* The `miaws` gem is sometimes used within kubernetes scripts, so the instance profile credentials will not work in those cases which is why it can't be used everywhere.

#### Dependencies (if any)


:card_index: [sc-158878]
