### PR TITLE
Add conditional dependencies to support both ruby 3.0+ and ruby 2.7 [sc-161583]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,8 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'faraday', '~> 2.8.1'
-gem 'faraday-net_http', '~> 3.0.2'
+gem 'faraday', '~> 2'
 gem 'httparty', '~> 0.23.1'
-gem 'multi_xml', '~> 0.6.0'
 
 group :test do
   gem 'rspec',    '~> 3.6'

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -9,6 +9,8 @@ Gem::Specification.new do |s|
   s.authors       = ['MI SRE']
   s.email         = 'devops@movableink.com'
 
+  s.required_ruby_version = '>= 2.6.0'
+
   s.add_runtime_dependency 'aws-sdk-core', '~> 3'
   s.add_runtime_dependency 'aws-sdk-athena', '~> 1'
   s.add_runtime_dependency 'aws-sdk-autoscaling', '~> 1'
@@ -26,9 +28,14 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sigv4', '~> 1'
   s.add_runtime_dependency 'httparty',  '0.23.1'
   s.add_runtime_dependency 'diplomat',  '2.6.4'
-  s.add_runtime_dependency 'faraday',  '~> 2.8.1'
-  s.add_runtime_dependency 'faraday-net_http', '~> 3.0.2'
-  s.add_runtime_dependency 'multi_xml', '~> 0.6.0'
+
+  if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('3.0.0')
+    s.add_runtime_dependency 'faraday',  '~> 2.8.1'
+    s.add_runtime_dependency 'faraday-net_http', '~> 3.0.2'
+    s.add_runtime_dependency 'multi_xml', '~> 0.6.0'
+  else
+    s.add_runtime_dependency 'faraday',  '~> 2'
+  end
 
   all_files  = `git ls-files`.split("\n")
   test_files = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.10.0'
+    VERSION = '2.11.0'
   end
 end


### PR DESCRIPTION
## Current Behavior

The last update works, but we're required to install seperate versions for cinc or with the system based on ruby versions.

## Why do we need this change?

Adding these dependencies should allow us to install the same version on both environments.

## Implementation Details



#### Dependencies (if any)


:card_index: [sc-161583]
