### PR TITLE
add autoscaling client with retries [sc-162448]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.1)
+    MovableInkAWS (2.11.2)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.0)
+    MovableInkAWS (2.11.1)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/autoscaling.rb
+++ b/lib/movable_ink/aws/autoscaling.rb
@@ -10,7 +10,7 @@ module MovableInk
 
       def autoscaling_with_retries(region: my_region)
         @autoscaling_client_with_retries ||= {}
-        instance_credentials = Aws::InstanceProfileCredentials.new(retries: 5)
+        instance_credentials = Aws::InstanceProfileCredentials.new(retries: 5, disable_imds_v1: true)
         @autoscaling_client_with_retries[region] ||= Aws::AutoScaling::Client.new(region: region, credentials: instance_credentials)
       end
 

--- a/lib/movable_ink/aws/autoscaling.rb
+++ b/lib/movable_ink/aws/autoscaling.rb
@@ -8,6 +8,12 @@ module MovableInk
         @autoscaling_client[region] ||= Aws::AutoScaling::Client.new(region: region)
       end
 
+      def autoscaling_with_retries(region: my_region)
+        @autoscaling_client_with_retries ||= {}
+        instance_credentials = Aws::InstanceProfileCredentials.new(retries: 5)
+        @autoscaling_client_with_retries[region] ||= Aws::AutoScaling::Client.new(region: region, credentials: instance_credentials)
+      end
+
       def mark_me_as_unhealthy
         run_with_backoff do
           autoscaling.set_instance_health({
@@ -75,6 +81,30 @@ module MovableInk
         else
           run_with_backoff do
             autoscaling.complete_lifecycle_action({
+              instance_id:             instance_id,
+              lifecycle_hook_name:     lifecycle_hook_name,
+              auto_scaling_group_name: auto_scaling_group_name,
+              lifecycle_action_result: 'CONTINUE'
+            })
+          end
+        end
+      end
+
+      def complete_lifecycle_action_with_retries(lifecycle_hook_name:, auto_scaling_group_name:, lifecycle_action_token: nil, instance_id: nil)
+        raise ArgumentError.new('lifecycle_action_token or instance_id required') if lifecycle_action_token.nil? && instance_id.nil?
+
+        if lifecycle_action_token
+          run_with_backoff do
+            autoscaling_with_retries.complete_lifecycle_action({
+              lifecycle_hook_name:     lifecycle_hook_name,
+              auto_scaling_group_name: auto_scaling_group_name,
+              lifecycle_action_token:  lifecycle_action_token,
+              lifecycle_action_result: 'CONTINUE'
+            })
+          end
+        else
+          run_with_backoff do
+            autoscaling_with_retries.complete_lifecycle_action({
               instance_id:             instance_id,
               lifecycle_hook_name:     lifecycle_hook_name,
               auto_scaling_group_name: auto_scaling_group_name,

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.0'
+    VERSION = '2.11.1'
   end
 end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.1'
+    VERSION = '2.11.2'
   end
 end


### PR DESCRIPTION
## Current Behavior

* There is a bug where the `sorcerer` instances are not able to successfully complete their termination handler:

```
Uncaught exception draining instance Aws::Errors::MissingCredentialsError: unable to sign request without credentials set.
```

## Why do we need this change?

* Add explicit retries into the library to ensure when the credentials retry error occurs, there is a re-try.

## Implementation Details

* Also explicitly disables imds_v1.
* Tested this change with `sorcerer` in `staging`. Keeping `complete_lifecycle_action`, so that if there is an error with the function we can still fall back to the previous one for now. We can remove it later.
* Uses InstanceProfileCredentials add re-tries to getting credentials: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/InstanceProfileCredentials.html

#### Dependencies (if any)


:card_index: [sc-162448]
