### PR TITLE
Optional allow_reassociation flag and ec2 api response for assign ip address call

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.3)
+    MovableInkAWS (2.11.4)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -258,20 +258,24 @@ module MovableInk
         unassigned_elastic_ips.select { |address| address.tags.detect { |t| t.key == 'mi:roles' && t.value == role } }
       end
 
-      def assign_ip_address_with_retries(role:)
+      def assign_ip_address_with_retries(role:, allow_reassociation: false)
+        response = nil
         run_with_backoff do
-          ec2_with_retries.associate_address({
+          response = ec2_with_retries.associate_address({
             instance_id: instance_id,
-            allocation_id: available_elastic_ips(role: role).sample.allocation_id
+            allocation_id: available_elastic_ips(role: role).sample.allocation_id,
+            allow_reassociation: allow_reassociation
           })
         end
+        response
       end
 
-      def assign_ip_address(role:)
+      def assign_ip_address(role:, allow_reassociation: false)
         run_with_backoff do
           ec2.associate_address({
             instance_id: instance_id,
-            allocation_id: available_elastic_ips(role: role).sample.allocation_id
+            allocation_id: available_elastic_ips(role: role).sample.allocation_id,
+            allow_reassociation: allow_reassociation
           })
         end
       end

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -250,7 +250,7 @@ module MovableInk
         ]
         begin
           run_with_backoff(expected_errors: expected_errors) do
-            response = ec2.describe_addresses({
+            response = ec2_with_retries.describe_addresses({
               public_ips: [public_ip]
             })
             raise MovableInk::AWS::Errors::ServiceError if response.length > 1

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.3'
+    VERSION = '2.11.4'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -692,6 +692,40 @@ describe MovableInk::AWS::EC2 do
 
         expect(aws.assign_ip_address(role: 'some_role').association_id).to eq('eipassoc-3')
       end
+
+      it "should assign an elastic IP with allow_reassociation flag" do
+        ec2.stub_responses(:describe_addresses, elastic_ip_data)
+        ec2.stub_responses(:associate_address, associate_address_data)
+        allow(aws).to receive(:my_region).and_return('us-east-1')
+        allow(aws).to receive(:instance_id).and_return('i-12345')
+        allow(aws).to receive(:ec2).and_return(ec2)
+
+        expect(aws.assign_ip_address(role: 'some_role', allow_reassociation: true).association_id).to eq('eipassoc-3')
+      end
+
+      it "should assign an elastic IP with retries and return response" do
+        ec2.stub_responses(:describe_addresses, elastic_ip_data)
+        ec2.stub_responses(:associate_address, associate_address_data)
+        allow(aws).to receive(:my_region).and_return('us-east-1')
+        allow(aws).to receive(:instance_id).and_return('i-12345')
+        allow(aws).to receive(:ec2).and_return(ec2)
+        allow(aws).to receive(:ec2_with_retries).and_return(ec2)
+
+        response = aws.assign_ip_address_with_retries(role: 'some_role')
+        expect(response.association_id).to eq('eipassoc-3')
+      end
+
+      it "should assign an elastic IP with retries and allow_reassociation flag" do
+        ec2.stub_responses(:describe_addresses, elastic_ip_data)
+        ec2.stub_responses(:associate_address, associate_address_data)
+        allow(aws).to receive(:my_region).and_return('us-east-1')
+        allow(aws).to receive(:instance_id).and_return('i-12345')
+        allow(aws).to receive(:ec2).and_return(ec2)
+        allow(aws).to receive(:ec2_with_retries).and_return(ec2)
+
+        response = aws.assign_ip_address_with_retries(role: 'some_role', allow_reassociation: true)
+        expect(response.association_id).to eq('eipassoc-3')
+      end
     end
 
     context 'elastic ips' do


### PR DESCRIPTION
## Why do we need this change?

1. Optional allow_reassociation flag for associate EIP EC2 API call
2. Response from EC2 API is returned in assign_ip_address_with_retries so we can run some validations

## Implementation Details



#### Dependencies (if any)


:card_index: [sc-177454]
