### PR TITLE
fix EC2 placement zone retrieval [sc-180267]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.4)
+    MovableInkAWS (2.11.5)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -161,7 +161,7 @@ module MovableInk
               value: role
             }
           ],
-          placement: { availability_zone: nil }
+          placement: { availability_zone: endpoint.Service.dig('Meta', 'external-k8s-topology-zone') }
         })
       end
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.4'
+    VERSION = '2.11.5'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -418,6 +418,7 @@ describe MovableInk::AWS::EC2 do
               "Meta": {
                 "external-source": "kubernetes",
                 "external-k8s-ns": "default",
+                "external-k8s-topology-zone": "us-east-1a",
               }
             }
           }
@@ -484,7 +485,7 @@ describe MovableInk::AWS::EC2 do
          expect(roles_tag[:value]).to eq('kubernetes-service-name')
          expect(backend.instance_id).to eq(nil)
          expect(backend.private_ip_address).to eq('10.0.0.1')
-         expect(backend.private_ip_address).to eq('10.0.0.1')
+         expect(backend.placement[:availability_zone]).to eq('us-east-1a')
       end
     end
 


### PR DESCRIPTION
## Current Behavior
service discovery of k8s pods does not work if you specify an AZ.

## Why do we need this change?

We want to discover pods by their AZ.

## Implementation Details



#### Dependencies (if any)


:card_index: [sc-180267]
