### PR TITLE
Add support for Consul service mesh discovery for EKS pods

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.5)
+    MovableInkAWS (2.11.6)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -136,7 +136,11 @@ module MovableInk
         # within MI configuration
         Diplomat::Health.service(role.gsub('_', '-'), consul_service_options).map { |endpoint|
           if endpoint.Node.dig('Meta', 'external-source') == 'kubernetes'
+            # Legacy catalog sync
             map_k8s_consul_endpoint(endpoint, role)
+          elsif endpoint.Service && endpoint.Service.dig('Meta', 'managed-by') == 'consul-k8s-endpoints-controller'
+            # Consul mesh with service mesh sidecar
+            map_k8s_consul_mesh_endpoint(endpoint, role)
           else
             map_ec2_consul_endpoint(endpoint)
           end
@@ -162,6 +166,40 @@ module MovableInk
             }
           ],
           placement: { availability_zone: endpoint.Service.dig('Meta', 'external-k8s-topology-zone') }
+        })
+      end
+
+      def map_k8s_consul_mesh_endpoint(endpoint, role)
+        OpenStruct.new ({
+          private_ip_address: endpoint.Service.dig('Address'),
+          instance_id: nil,
+          tags: [
+            {
+              key: 'Name',
+              value: endpoint.Service.dig('Meta', 'pod-name')
+            },
+            {
+              key: 'mi:roles',
+              value: role
+            },
+            {
+              key: 'mi:monitoring_roles',
+              value: role
+            },
+            {
+              key: 'k8s:namespace',
+              value: endpoint.Service.dig('Meta', 'k8s-namespace')
+            },
+            {
+              key: 'k8s:service',
+              value: endpoint.Service.dig('Meta', 'k8s-service-name')
+            },
+            {
+              key: 'k8s:pod-uid',
+              value: endpoint.Service.dig('Meta', 'pod-uid')
+            }
+          ],
+          placement: { availability_zone: endpoint.Service.dig('Locality', 'Zone') }
         })
       end
 

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.5'
+    VERSION = '2.11.6'
   end
 end

--- a/spec/ec2_spec.rb
+++ b/spec/ec2_spec.rb
@@ -487,6 +487,99 @@ describe MovableInk::AWS::EC2 do
          expect(backend.private_ip_address).to eq('10.0.0.1')
          expect(backend.placement[:availability_zone]).to eq('us-east-1a')
       end
+
+      it "returns backends that are synced from consul mesh with service mesh sidecar" do
+        consul_mesh_service_instances = [
+          {
+            "Node": {
+              "ID": "",
+              "Node": "k8s-mesh-virtual-node",
+              "Address": "10.0.0.10",
+              "Datacenter": my_datacenter,
+              "TaggedAddresses": nil,
+              "Meta": {
+                "synthetic-node": "true"
+              },
+              "CreateIndex": 12345,
+              "ModifyIndex": 12345
+            },
+            "Service": {
+              "ID": "test-service-abc123-xyz-test-service",
+              "Service": "test-service",
+              "Tags": [],
+              "Address": "10.0.0.11",
+              "Meta": {
+                "k8s-namespace": "default",
+                "k8s-service-name": "test-service",
+                "managed-by": "consul-k8s-endpoints-controller",
+                "pod-name": "test-service-abc123-xyz",
+                "pod-uid": "00000000-0000-0000-0000-000000000000",
+                "synthetic-node": "true"
+              },
+              "Port": 8080,
+              "Weights": {
+                "Passing": 1,
+                "Warning": 1
+              },
+              "EnableTagOverride": false,
+              "Locality": {
+                "Region": "us-east-1",
+                "Zone": "us-east-1b"
+              },
+              "Proxy": {
+                "Mode": "",
+                "MeshGateway": {},
+                "Expose": {}
+              },
+              "Connect": {},
+              "PeerName": "",
+              "CreateIndex": 12345,
+              "ModifyIndex": 12345
+            },
+            "Checks": [
+              {
+                "Node": "k8s-mesh-virtual-node",
+                "CheckID": "default/test-service-abc123-xyz-test-service",
+                "Name": "Kubernetes Readiness Check",
+                "Status": "passing",
+                "Notes": "",
+                "Output": "Kubernetes health checks passing",
+                "ServiceID": "test-service-abc123-xyz-test-service",
+                "ServiceName": "test-service",
+                "ServiceTags": [],
+                "Type": "kubernetes-readiness",
+                "Interval": "",
+                "Timeout": "",
+                "ExposedPort": 0,
+                "Definition": {},
+                "CreateIndex": 12345,
+                "ModifyIndex": 12345
+              }
+            ]
+          }
+        ]
+
+        json = JSON.generate(consul_mesh_service_instances)
+        stub_request(:get, "https://localhost:8501/v1/health/service/test-service?cached=true&dc=#{my_datacenter}&passing=true&stale=true")
+          .to_return(status: 200, body: json, headers: {})
+
+         resp_instances = aws.instances(role: 'test-service', discovery_type: 'consul')
+         backend = resp_instances.first
+         name_tag = backend.tags.find {|t| t[:key] == 'Name' }
+         roles_tag = backend.tags.find {|t| t[:key] == 'mi:roles' }
+         k8s_namespace_tag = backend.tags.find {|t| t[:key] == 'k8s:namespace' }
+         k8s_service_tag = backend.tags.find {|t| t[:key] == 'k8s:service' }
+         k8s_pod_uid_tag = backend.tags.find {|t| t[:key] == 'k8s:pod-uid' }
+
+         expect(name_tag[:value]).to eq('test-service-abc123-xyz')
+         expect(roles_tag[:value]).to eq('test-service')
+         expect(k8s_namespace_tag[:value]).to eq('default')
+         expect(k8s_service_tag[:value]).to eq('test-service')
+         expect(k8s_pod_uid_tag[:value]).to eq('00000000-0000-0000-0000-000000000000')
+         expect(backend.instance_id).to eq(nil)
+         expect(backend.private_ip_address).to eq('10.0.0.11')
+         expect(backend.placement[:availability_zone]).to eq('us-east-1b')
+      end
     end
 
     context "ordered roles" do


### PR DESCRIPTION
## Current Behavior

The library currently supports EKS pod discovery through Consul catalog sync, which identifies Kubernetes pods by the `external-source: kubernetes` metadata set by the catalog sync process.

## Why do we need this change?

We are migrating from Consul catalog sync to Consul service mesh with sidecar injection. Pods with service mesh sidecars are registered differently in Consul:
- Managed by `consul-k8s-endpoints-controller` instead of catalog sync
- Different metadata structure (Service.Meta vs Node.Meta)
- Availability zone in Locality.Zone instead of Meta field

This change allows us to gradually migrate services to the mesh while maintaining discovery for both types of pods.

## Implementation Details

- Added `map_k8s_consul_mesh_endpoint()` method to handle Consul mesh pod metadata
- Detection based on `managed-by: consul-k8s-endpoints-controller` in Service.Meta
- Extracts pod name from Service.Meta instead of Service.ID
- Extracts availability zone from Service.Locality.Zone
- Includes additional Kubernetes metadata tags: k8s:namespace, k8s:service, k8s:pod-uid
- Coexists with existing catalog sync detection - both methods work in parallel
- Added comprehensive test coverage with anonymized test data

#### Dependencies (if any)

None

:card_index: [sc-184030]