### PR TITLE
Update EC2 methods to support EIP pool filtering and bump version to 2.11.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,13 +13,13 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: ${{ matrix.ruby-version }}
 
@@ -35,10 +35,10 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Install ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
       with:
         ruby-version: 3.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PATH
       diplomat (= 2.6.4)
       faraday (~> 2)
       httparty (= 0.23.1)
+      ostruct
 
 GEM
   remote: https://rubygems.org/
@@ -105,6 +106,7 @@ GEM
     logger (1.7.0)
     mini_mime (1.1.5)
     multi_xml (0.6.0)
+    ostruct (0.5.2)
     public_suffix (5.1.1)
     rexml (3.4.1)
     rspec (3.13.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    MovableInkAWS (2.11.6)
+    MovableInkAWS (2.11.7)
       aws-sdk-athena (~> 1)
       aws-sdk-autoscaling (~> 1)
       aws-sdk-cloudwatch (~> 1)

--- a/MovableInkAWS.gemspec
+++ b/MovableInkAWS.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-sns', '~> 1'
   s.add_runtime_dependency 'aws-sdk-ssm', '~> 1'
   s.add_runtime_dependency 'aws-sigv4', '~> 1'
+  s.add_runtime_dependency 'ostruct'
   s.add_runtime_dependency 'httparty',  '0.23.1'
   s.add_runtime_dependency 'diplomat',  '2.6.4'
 

--- a/lib/movable_ink/aws/ec2.rb
+++ b/lib/movable_ink/aws/ec2.rb
@@ -309,27 +309,31 @@ module MovableInk
         @unassigned_elastic_ips ||= elastic_ips.select { |address| address.association_id.nil? }
       end
 
-      def available_elastic_ips(role:)
-        unassigned_elastic_ips.select { |address| address.tags.detect { |t| t.key == 'mi:roles' && t.value == role } }
+      def available_elastic_ips(role:, eip_pool: nil)
+        if eip_pool
+          unassigned_elastic_ips.select { |address| address.tags.detect { |t| t.key == 'mi:eip-pool' && t.value == eip_pool } }
+        else
+          unassigned_elastic_ips.select { |address| address.tags.detect { |t| t.key == 'mi:roles' && t.value == role } }
+        end
       end
 
-      def assign_ip_address_with_retries(role:, allow_reassociation: false)
+      def assign_ip_address_with_retries(role:, eip_pool: nil, allow_reassociation: false)
         response = nil
         run_with_backoff do
           response = ec2_with_retries.associate_address({
             instance_id: instance_id,
-            allocation_id: available_elastic_ips(role: role).sample.allocation_id,
+            allocation_id: available_elastic_ips(role: role, eip_pool: eip_pool).sample.allocation_id,
             allow_reassociation: allow_reassociation
           })
         end
         response
       end
 
-      def assign_ip_address(role:, allow_reassociation: false)
+      def assign_ip_address(role:, eip_pool: nil, allow_reassociation: false)
         run_with_backoff do
           ec2.associate_address({
             instance_id: instance_id,
-            allocation_id: available_elastic_ips(role: role).sample.allocation_id,
+            allocation_id: available_elastic_ips(role: role, eip_pool: eip_pool).sample.allocation_id,
             allow_reassociation: allow_reassociation
           })
         end

--- a/lib/movable_ink/version.rb
+++ b/lib/movable_ink/version.rb
@@ -1,5 +1,5 @@
 module MovableInk
   class AWS
-    VERSION = '2.11.6'
+    VERSION = '2.11.7'
   end
 end


### PR DESCRIPTION
## Current Behavior
The EC2 methods do not support filtering by Elastic IP (EIP) pools.

## Why do we need this change?
Adding support for EIP pool filtering enhances the flexibility of IP address management.

## Implementation Details
Updated the `available_elastic_ips` and `assign_ip_address` methods to accept an optional `eip_pool` parameter for filtering. Bumped the version to 2.11.7.

#### Dependencies (if any)


:card_index: [sc-202597]

